### PR TITLE
Issue eclipse/rdf4j#920: Close http session after ping

### DIFF
--- a/console/src/main/java/org/eclipse/rdf4j/console/Connect.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/Connect.java
@@ -79,14 +79,13 @@ public class Connect implements Command {
 			// Ping server
 			final HttpClientSessionManager client = new SharedHttpClientSessionManager();
 			try {
-				RDF4JProtocolSession httpClient = client.createRDF4JProtocolSession(url);
-
-				if (user != null) {
-					httpClient.setUsernameAndPassword(user, pass);
+				try (RDF4JProtocolSession httpClient = client.createRDF4JProtocolSession(url)) {
+					if (user != null) {
+						httpClient.setUsernameAndPassword(user, pass);
+					}
+					// Ping the server
+					httpClient.getServerProtocol();
 				}
-
-				// Ping the server
-				httpClient.getServerProtocol();
 			}
 			finally {
 				client.shutDown();


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: eclipse/rdf4j#920 .

* RDF4JProtocolSession now implements AutoCloseable and needs to be closed
