### PR TITLE
Fix eclipse/rdf4j#880: Reset transaction time after request is proces…

### DIFF
--- a/compliance/server/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTransactionTest.java
+++ b/compliance/server/src/test/java/org/eclipse/rdf4j/repository/http/HTTPRepositoryTransactionTest.java
@@ -1,0 +1,43 @@
+package org.eclipse.rdf4j.repository.http;
+
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.Test;
+
+public class HTTPRepositoryTransactionTest {
+
+	private static final String CACHE_TIMEOUT_PROPERTY = "rdf4j.server.txn.registry.timeout";
+
+	private static HTTPMemServer server;
+
+	private HTTPRepository testRepository;
+
+	@Test
+	public void testTimeout()
+		throws Exception
+	{
+		try {
+			System.setProperty(CACHE_TIMEOUT_PROPERTY, Integer.toString(2));
+			server = new HTTPMemServer();
+			try {
+				server.start();
+				testRepository = new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
+				testRepository.initialize();
+			}
+			catch (Exception e) {
+				server.stop();
+				throw e;
+			}
+			try (RepositoryConnection connection = testRepository.getConnection()) {
+				connection.begin();
+				Thread.sleep(3000); // sleep for longer then the timeout
+				connection.commit(); // was transaction removed due to timeout?
+			}
+			testRepository.shutDown();
+		}
+		finally {
+			server.stop();
+			System.clearProperty(CACHE_TIMEOUT_PROPERTY);
+		}
+	}
+
+}

--- a/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
+++ b/server-spring/src/main/java/org/eclipse/rdf4j/http/server/repository/transaction/TransactionController.java
@@ -26,11 +26,13 @@ import static org.eclipse.rdf4j.http.protocol.Protocol.USING_GRAPH_PARAM_NAME;
 import static org.eclipse.rdf4j.http.protocol.Protocol.USING_NAMED_GRAPH_PARAM_NAME;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -160,6 +162,11 @@ public class TransactionController extends AbstractController {
 							"Method not allowed: " + reqMethod);
 				}
 				break;
+			case PING:
+				String text = Long.toString(ActiveTransactionRegistry.INSTANCE.getTimeout(TimeUnit.MILLISECONDS));
+				Map<String, String> model = Collections.singletonMap(SimpleResponseView.CONTENT_KEY, text);
+				result = new ModelAndView(SimpleResponseView.getInstance(), model);
+				break;
 			default:
 				// TODO Action.ROLLBACK check is for backward compatibility with
 				// older 2.8.x releases only. It's not in the protocol spec.
@@ -188,6 +195,7 @@ public class TransactionController extends AbstractController {
 				}
 				break;
 		}
+		ActiveTransactionRegistry.INSTANCE.active(transaction);
 		return result;
 	}
 


### PR DESCRIPTION
…sed and after client sends a PING request

Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: eclipse/rdf4j#880 eclipse/rdf4j#852 eclipse/rdf4j#851 eclipse/rdf4j/#363.
* Understands the new PING action from eclipse/rdf4j#929 and response with the server side transaction timeout
* Reactivates the transaction after processing it, as the processing might be significantly long (relative to the timeout)
