### PR TITLE
Fix #31: Use regex to parse version string

### DIFF
--- a/config/src/main/java/org/eclipse/rdf4j/common/app/AppVersion.java
+++ b/config/src/main/java/org/eclipse/rdf4j/common/app/AppVersion.java
@@ -8,6 +8,8 @@
 package org.eclipse.rdf4j.common.app;
 
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.rdf4j.common.lang.ObjectUtil;
 
@@ -17,6 +19,8 @@ import org.eclipse.rdf4j.common.lang.ObjectUtil;
  * release, e.g. beta1 or RC1. Combined, this results in versions like 2.0 and 4.1-beta1.
  */
 public class AppVersion implements Comparable<AppVersion> {
+
+	private static final Pattern VERSION_REGEX = Pattern.compile("^\\s*(\\d+)(?:\\.(\\d+)(?:\\.(\\d+))?)?(M[^\\-\\+]*)?(?:-([^\\+]+))?(?:\\+(.+))?\\s*$");
 
 	/**
 	 * The version's major version number.
@@ -270,11 +274,15 @@ public class AppVersion implements Comparable<AppVersion> {
 			return new AppVersion(-1, -1, "dev");
 		}
 
-		int minorSeparator = versionString.indexOf('.');
-		int patchSeparator = versionString.indexOf('.', minorSeparator + 1);
-		int milestoneSeparator = versionString.indexOf('M', Math.max(minorSeparator, patchSeparator));
-		int modifierSeparator = versionString.indexOf('-', Math.max(minorSeparator, milestoneSeparator));
-		int buildSeparator = versionString.indexOf('+', Math.max(Math.max(minorSeparator, milestoneSeparator), modifierSeparator));
+		Matcher m = VERSION_REGEX.matcher(versionString);
+		if (!m.find()) {
+			throw new NumberFormatException("Illegal version string: " + versionString);
+		}
+		int minorSeparator = m.start(2)-1;
+		int patchSeparator = m.start(3)-1;
+		int milestoneSeparator = m.start(4);
+		int modifierSeparator = m.start(5)-1;
+		int buildSeparator = m.start(6)-1;
 
 		if (minorSeparator == -1) {
 			throw new NumberFormatException("Illegal version string: " + versionString);

--- a/config/src/test/java/org/eclipse/rdf4j/common/app/AppVersionTest.java
+++ b/config/src/test/java/org/eclipse/rdf4j/common/app/AppVersionTest.java
@@ -10,6 +10,7 @@ package org.eclipse.rdf4j.common.app;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import org.eclipse.rdf4j.RDF4J;
 import org.junit.Test;
 
 /**
@@ -27,19 +28,77 @@ public class AppVersionTest {
 		assertEquals(0, v.getMinor());
 		assertEquals(3, v.getPatch());
 		assertNull(v.getModifier());
+	}
 
+	@Test
+	public void testCreateFromStringSnapshot()
+		throws Exception
+	{
+		AppVersion  v;
 		v = AppVersion.parse("2.8.0-beta3-SNAPSHOT");
 		assertEquals(2, v.getMajor());
 		assertEquals(8, v.getMinor());
 		assertEquals(0, v.getPatch());
 		assertEquals("beta3-SNAPSHOT", v.getModifier());
 
+	}
+
+	@Test
+	public void testCreateFromStringMilestone()
+		throws Exception
+	{
+		AppVersion  v;
 		v = AppVersion.parse("1.0M1");
 		assertEquals(1, v.getMajor());
 		assertEquals(0, v.getMinor());
 		assertEquals(-1, v.getPatch());
 		assertEquals(1, v.getMilestone());
 		assertNull(v.getModifier());
+	}
+
+	@Test
+	public void testCreateFromStringBeta()
+		throws Exception
+	{
+		AppVersion  v;
+		v = AppVersion.parse("1.0.0-beta3");
+		assertEquals(1, v.getMajor());
+		assertEquals(0, v.getMinor());
+		assertEquals(0, v.getPatch());
+		assertEquals("beta3", v.getModifier());
+	}
+
+	@Test
+	public void testCreateFromStringModifier()
+		throws Exception
+	{
+		AppVersion  v;
+		v = AppVersion.parse("1.0.0-M1");
+		assertEquals(1, v.getMajor());
+		assertEquals(0, v.getMinor());
+		assertEquals(0, v.getPatch());
+		assertEquals("M1", v.getModifier());
+	}
+
+	@Test
+	public void testCreateFromStringModifierMilestone()
+		throws Exception
+	{
+		AppVersion  v;
+		v = AppVersion.parse("1.0.0-GAMMA");
+		assertEquals(1, v.getMajor());
+		assertEquals(0, v.getMinor());
+		assertEquals(0, v.getPatch());
+		assertEquals("GAMMA", v.getModifier());
+	}
+
+	@Test
+	public void testCurrentVersion()
+		throws Exception
+	{
+		AppVersion  v;
+		v = AppVersion.parse(RDF4J.getVersion());
+		assertEquals(RDF4J.getVersion(), v.toString());
 	}
 
 	@Test


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #31 .
* Use a RegExp to parse version string to ensure 'M' is not miss calculated
