### PR TITLE
Fix #36: Add swagger.yaml based on rdf4j.yaml 9aedafad from graphdb

### DIFF
--- a/server/src/main/webapp/swagger.yaml
+++ b/server/src/main/webapp/swagger.yaml
@@ -1,0 +1,743 @@
+swagger: "2.0"
+info:
+  title: RDF4J API
+  version: 2.0.0
+basePath: /rdf4j-server
+externalDocs:
+  url: http://docs.rdf4j.org/rest-api/
+tags:
+  - name: repositories
+    description: Repository management
+  - name: sparql
+    description: SPARQL
+  - name: contexts
+    description: Contexts management
+  - name: namespaces
+    description: Namespaces management
+  - name: graph-store
+    description: Graph Store protocol
+  - name: transactions
+    description: Transactions management
+  - name: protocol
+    description: Protocol verification
+paths:
+  /protocol:
+    get:
+      tags:
+        - protocol
+      summary: Fetch the protocol version
+      description: The version of the protocol that the server uses to communicate over HTTP.
+      responses:
+        200:
+          description: The protocol version
+          schema:
+            type: integer
+            format: int32
+          examples:
+            text/plain: 8
+      produces:
+        - text/plain
+  /repositories:
+    get:
+      tags:
+        - repositories
+      summary: An overview of the repositories that are available on a server.
+      description: Get an list of available repositories, including ID, title, read- and write access parameters for each listed repository. The list is formatted as a tuple query result with variables 'uri', 'id', 'title', 'readable' and 'writable'. The 'uri' value gives the URI/URL for the repository and the 'readable' and 'writable' values are xsd:boolean typed literals indicating read- and write permissions.
+      responses:
+        200:
+          description: Repository list
+          schema:
+            type: string
+            format: binary
+      produces:
+        - application/sparql-results+xml
+  /repositories/{repositoryID}:
+    get:
+      tags:
+        - repositories
+      summary: Send queries on a specific repository with ID. This resource represents a SPARQL query endpoint
+      description: The main endpoint that is responsible for sending queries to a particular repository
+      parameters:
+        - name: repositoryID
+          in: path
+          description: The repository ID
+          required: true
+          type: string
+        - name: query
+          in: query
+          description: The query to evaluate
+          required: true
+          type: string
+        - name: queryLn
+          in: query
+          description: Specifies the query language that is used for the query. Acceptable values are strings denoting the query languages supported by the server, i.e. 'serql' for SeRQL queries and 'sparql' for SPARQL queries. If not specified, the server assumes the query is a SPARQL query
+          required: false
+          type: string
+        - name: infer
+          in: query
+          description: Specifies whether inferred statements should be included in the query evaluation. Inferred statements are included by default. Specifying any value other than 'true' (ignoring case) restricts the query evluation to explicit statements only.
+          required: false
+          type: boolean
+        - name: $<varname>
+          in: query
+          required: false
+          description: Specifies variable bindings. Variables appearing in the query can be bound to a specific value outside the actual query using this option. The value should be an N-Triples encoded RDF value.
+          type: string
+        - name: timeout
+          in: query
+          required: false
+          description: Specifies a maximum query execution time, in whole seconds. The value should be an integer. A setting of 0 or a negative number indicates unlimited query time (the default).
+          type: integer
+        - name: distinct
+          in: query
+          required: false
+          description: Specifies if only distinct query solutions should be returned. The value should be true or false. If the supplied SPARQL query itself already has a DISTINCT modifier, this parameter will have no effect.
+          type: boolean
+        - name: limit
+          in: query
+          required: false
+          description: Specifies the maximum number of query solutions to return. The value should be a positive integer. If the supplied SPARQL query itself already has a LIMIT modifier, this parameter will only have an effect if the supplied value is lower than the LIMIT value in the query.
+          type: integer
+        - name: offset
+          in: query
+          required: false
+          description: Specifies the number of query solutions to skip. The value should be a positive integer. This parameter is cumulative with any OFFSET modifier in the supplied SPARQL query itself.
+          type: integer
+      responses:
+        200:
+          description: Result from the sparql query
+          schema:
+            type: string
+            format: binary
+      produces:
+        - application/sparql-results+xml
+        - application/sparql-results+json
+        - application/x-binary-rdf-results-table
+        - text/boolean
+        - application/rdf+xml
+        - text/plain
+        - text/turtle
+        - text/rdf+n3
+        - text/x-nquads
+        - application/ld+json
+        - application/rdf+json
+        - application/trix
+        - application/x-trig
+        - application/x-binary-rdf
+    post:
+      tags:
+        - repositories
+      summary: >-
+        Send queries on a specific repository with ID. This resource represents
+        a SPARQL query endpoint
+      description: >-
+        The main endpoint that is responsible for sending queries to a
+        particular repository
+      parameters:
+        - name: repositoryID
+          in: path
+          description: The repository ID
+          required: true
+          type: string
+      consumes:
+        - application/sparql-query
+        - application/x-www-form-urlencoded
+      responses:
+        200:
+          description: Result from the sparql query
+          schema:
+            type: string
+            format: binary
+      produces:
+        - application/sparql-results+xml
+        - application/sparql-results+json
+        - application/x-binary-rdf-results-table
+        - text/boolean
+        - application/rdf+xml
+        - text/plain
+        - text/turtle
+        - text/rdf+n3
+        - text/x-nquads
+        - application/ld+json
+        - application/rdf+json
+        - application/trix
+        - application/x-trig
+        - application/x-binary-rdf
+    delete:
+      tags:
+        - repositories
+      summary: Repository removal
+      description: "Delete a specific repository by ID. Care should be taken with the use of this method: the result of this operation is the complete removal of the repository from the server, including its configuration settings and (if present) data directory"
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+      responses:
+        204:
+          description: The repository was deleted
+  /repositories/{repositoryID}/statements:
+    get:
+      tags:
+        - sparql
+      summary: Fetches statements from the repository.
+      description: Get statements from the repository matching the filtering parameters
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: subj
+          in: query
+          description: Restricts the operation to statements with the specified N-Triples encoded resource as subject.
+          type: string
+        - name: pred
+          in: query
+          description: Restricts the operation to statements with the specified N-Triples encoded URI as predicate.
+          type: string
+        - name: obj
+          in: query
+          description: Restricts the operation to statements with the specified N-Triples encoded value as object.
+          type: string
+        - name: context
+          in: query
+          description: If specified, restricts the operation to one or more specific contexts in the repository. The value of this parameter is either an N-Triples encoded URI or bnode ID, or the special value 'null' which represents all context-less statements. If multiple 'context' parameters are specified, the request will operate on the union of all specified contexts. The operation is executed on all statements that are in the repository if no context is specified.
+          type: string
+        - name: infer
+          in: query
+          description: Specifies whether inferred statements should be included in the result of GET requests. Inferred statements are included by default. Specifying any value other than 'true' (ignoring case) restricts the request to explicit statements only.
+          type: string
+      responses:
+        200:
+          description: Statements result
+          schema:
+            type: string
+            format: binary
+      produces:
+        - application/rdf+xml
+        - text/plain
+        - text/turtle
+        - text/rdf+n3
+        - text/x-nquads
+        - application/rdf+json
+        - application/trix
+        - application/x-trig
+        - application/x-binary-rdf
+    delete:
+      tags:
+        - sparql
+      summary: Deletes statements from the repository.
+      description: Deletes statements from the repository matching the filtering parameters
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: subj
+          in: query
+          description: Restricts the operation to statements with the specified N-Triples encoded resource as subject.
+          type: string
+        - name: pred
+          in: query
+          description: Restricts the operation to statements with the specified N-Triples encoded URI as predicate.
+          type: string
+        - name: obj
+          in: query
+          description: Restricts the operation to statements with the specified N-Triples encoded value as object.
+          type: string
+        - name: context
+          in: query
+          description: If specified, restricts the operation to one or more specific contexts in the repository. The value of this parameter is either an N-Triples encoded URI or bnode ID, or the special value 'null' which represents all context-less statements. If multiple 'context' parameters are specified, the request will operate on the union of all specified contexts. The operation is executed on all statements that are in the repository if no context is specified.
+          type: string
+      responses:
+        204:
+          description: The statements were successfully deleted
+    put:
+      tags:
+        - sparql
+      summary: Updates data in the repository, replacing any existing data with the supplied data
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: context
+          in: query
+          description: If specified, restricts the operation to one or more specific contexts in the repository. The value of this parameter is either an N-Triples encoded URI or bnode ID, or the special value 'null' which represents all context-less statements. If multiple 'context' parameters are specified, the request will operate on the union of all specified contexts. The operation is executed on all statements that are in the repository if no context is specified.
+          type: string
+        - name: baseURI
+          in: query
+          description: Specifies the base URI to resolve any relative URIs found in uploaded data against
+          type: string
+      responses:
+        204:
+          description: The data was seccussfully updated
+      consumes:
+        - application/rdf+xml
+        - text/plain
+        - text/turtle
+        - text/rdf+n3
+        - text/x-nquads
+        - application/rdf+json
+        - application/trix
+        - application/x-trig
+        - application/x-binary-rdf
+    post:
+      tags:
+        - sparql
+      summary: Performs updates on the data in the repository
+      description: The data supplied with this request is expected to contain either an RDF document, a SPARQL 1.1 Update string, or a special purpose transaction document. If an RDF document is supplied, the statements found in the RDF document will be added to the repository. If a SPARQL 1.1 Update string is supplied, the update operation will be parsed and executed. If a transaction document is supplied, the updates specified in the transaction document will be executed.
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: update
+          in: query
+          description: Only relevant for POST operations. Specifies the SPARQL 1.1 Update string to be executed. The value is expected to be a syntactically valid SPARQL 1.1 Update string.
+          type: string
+        - name: baseURI
+          in: query
+          description: Specifies the base URI to resolve any relative URIs found in uploaded data against. This parameter only applies to the PUT and POST method.
+          type: string
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/x-rdftransaction
+        - application/rdf+xml
+        - text/plain
+        - text/turtle
+        - text/rdf+n3
+        - text/x-nquads
+        - application/rdf+json
+        - application/trix
+        - application/x-trig
+        - application/x-binary-rdf
+      responses:
+        204:
+          description: The data was seccussfully updated
+  /repositories/{repositoryID}/size:
+    get:
+      tags:
+        - repositories
+      summary: The repository size (defined as the number of statements it contains)
+      description: The endpoint will give you the number of statements in the repository or in the given context
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: context
+          in: query
+          type: string
+          description: If specified, restricts the operation to one or more specific contexts in the repository. The value of this parameter is either an N-Triples encoded URI or bnode ID, or the special value 'null' which represents all context-less statements. If multiple 'context' parameters are specified, the request will operate on the union of all specified contexts. The operation is executed on all statements that are in the repository if no context is specified.
+      responses:
+        200:
+          description: Get the size of a specific context if given in the specified repository
+          schema:
+            type: integer
+  /repositories/{repositoryID}/contexts:
+    get:
+      tags:
+        - contexts
+      summary: Gets a list of resources that are used as context identifiers.
+      description: The list is formatted as a tuple query result with a single variable “contextID”, which is bound to URIs and bnodes that are used as context identifiers.
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+      responses:
+        200:
+          description: List of contexts was successfully retrieved.
+          schema:
+            type: string
+            format: binary
+      produces:
+        - application/sparql-results+xml
+        - application/sparql-results+json
+        - application/x-binary-rdf-results-table
+  /repositories/{repositoryID}/namespaces:
+    get:
+      tags:
+        - namespaces
+      summary: Fetch all namespace declaration info
+      description: Fetch all namespace declaration info
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+      responses:
+        200:
+          description: List of contexts was successfully retrieved.
+          schema:
+            type: string
+            format: binary
+      produces:
+        - application/sparql-results+xml
+        - application/sparql-results+json
+        - application/x-binary-rdf-results-table
+    delete:
+      tags:
+        - namespaces
+      summary: Remove all namespace declarations from the repository
+      description: Remove all namespace declarations from the repository
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+      responses:
+        204:
+          description: All namespaces were removed
+  /repositories/{repositoryID}/namespaces/{namespacesPrefix}:
+    get:
+      tags:
+        - namespaces
+      summary: Get namespace for a particular prefix
+      description: Gets the namespace that has been defined for a particular prefix.
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: namespacesPrefix
+          in: path
+          required: true
+          description: URI prefix of a RDF resource
+          type: string
+      responses:
+          200:
+            description: The defined namespace of the given prefix was successfully retrieved.
+            schema:
+              type: string
+      produces:
+        - text/plain
+    put:
+      tags:
+        - namespaces
+      summary: Set namespace for a particular prefix
+      description: Sets a new namespace for a particular prefix.
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: namespacesPrefix
+          in: path
+          required: true
+          description: URI prefix of a RDF resource
+          type: string
+      consumes:
+        - text/plain
+      responses:
+          204:
+            description: The defined namespace was successfully set to the given prefix.
+    delete:
+      tags:
+        - namespaces
+      summary: Remove namespace for a particular prefix
+      description: Removes the namespace that has been defined for a particular prefix.
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: namespacesPrefix
+          in: path
+          required: true
+          description: URI prefix of a RDF resource
+          type: string
+      responses:
+        204:
+          description: The defined namespace with the given prefix was successfully removed.
+  /repositories/{repositoryID}/rdf-graphs/{graph}:
+    get:
+      tags:
+        - graph-store
+      summary: Fetch all statements from a directly referenced named graph
+      description: Fetch all statements from a directly referenced named graph.
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: graph
+          in: path
+          required: true
+          description: URL path part uniquely identifying a named graph. After the request is executed the whole url is read as a named graph and statements from it can be retrieved.
+          type: string
+      responses:
+        200:
+          description: Statements result
+          schema:
+            type: string
+            format: binary
+      produces:
+        - application/rdf+xml
+        - text/plain
+        - text/turtle
+        - text/rdf+n3
+        - text/x-nquads
+        - application/rdf+json
+        - application/trix
+        - application/x-trig
+        - application/x-binary-rdf
+    post:
+      tags:
+        - graph-store
+      summary: Add statements to a directly referenced named graph
+      description: Add statements to a directly referenced named graph.
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: graph
+          in: path
+          required: true
+          description: URL path part uniquely identifying a named graph. The whole url is read as a named graph and statements from it can be retrieved.
+          type: string
+      consumes:
+        - application/rdf+xml
+        - text/plain
+        - text/turtle
+        - text/rdf+n3
+        - text/x-nquads
+        - application/rdf+json
+        - application/trix
+        - application/x-trig
+        - application/x-binary-rdf
+      responses:
+        204:
+          description: The data was seccussfully updated
+    delete:
+      tags:
+        - graph-store
+      summary: Clear a directly referenced named graph
+      description: Clear a directly referenced named graph.
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: graph
+          in: path
+          required: true
+          description: URL path part uniquely identifying a named graph. The whole url is read as a named graph and statements from it can be retrieved.
+          type: string
+      responses:
+        204:
+          description: Successfully cleared the defined named graph
+  /repositories/{repositoryID}/rdf-graphs/service:
+    get:
+      tags:
+        - graph-store
+      summary: Fetch all statements from an indirectly referenced named graph
+      description: Fetch all statements from an indirectly referenced named graph.
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: graph
+          in: query
+          required: false
+          description: Indirectly referenced named graph name. The named graph URI is mentioned as the value of this parameter.
+          type: string
+        - name: default
+          in: query
+          required: false
+          allowEmptyValue: true
+          description: Default named graph.
+          type: string
+      responses:
+        200:
+          description: Successfully retrieved statements from the defined or the default named graph
+          schema:
+            type: string
+            format: binary
+      produces:
+        - application/rdf+xml
+        - text/plain
+        - text/turtle
+        - text/rdf+n3
+        - text/x-nquads
+        - application/rdf+json
+        - application/trix
+        - application/x-trig
+        - application/x-binary-rdf
+  /repositories/{repositoryID}/transactions:
+    post:
+      tags:
+        - transactions
+      summary: Start a new transaction
+      description: Start a new transaction.
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+      responses:
+        201:
+          description: Started
+  /repositories/{repositoryID}/transactions/{transactionID}:
+    put:
+      tags:
+        - transactions
+      summary: Execute a transaction action
+      description: Execute a transaction action
+      parameters:
+        - name: repositoryID
+          in: path
+          required: true
+          description: The repository ID
+          type: string
+        - name: transactionID
+          in: path
+          required: true
+          description: The transaction ID
+          type: string
+        - name: action
+          in: query
+          required: true
+          enum:
+            - ADD
+            - DELETE
+            - GET
+            - UPDATE
+            - SIZE
+            - COMMIT
+            - PING
+          description: Type of possible actions in a transaction
+          type: string
+        - name: subj
+          in: query
+          required: false
+          description: Restricts the operation to statements with the specified N-Triples encoded resource as subject.
+          type: string
+        - name: pred
+          in: query
+          required: false
+          description: Restricts the operation to statements with the specified N-Triples encoded resource as predicate.
+          type: string
+        - name: obj
+          in: query
+          required: false
+          description: Restricts the operation to statements with the specified N-Triples encoded resource as object.
+          type: string
+        - name: query
+          in: query
+          required: false
+          description: The query to evaluate.
+          type: string
+        - name: queryLn
+          in: query
+          required: false
+          description: Specifies the query language that is used for the query. Acceptable values are strings denoting the query languages supported by the server, i.e. 'serql' for SeRQL queries and 'sparql' for SPARQL queries. If not specified, the server assumes the query is a SPARQL query.
+          type: string
+        - name: infer
+          in: query
+          required: false
+          description: Specifies whether inferred statements should be included in the query evaluation. Inferred statements are included by default. Specifying any value other than 'true' (ignoring case) restricts the query evluation to explicit statements only.
+          type: boolean
+        - name: update
+          in: query
+          required: false
+          description: Specifies the Update operation to be executed. The value is expected to be a syntactically valid SPARQL 1.1 Update string.
+          type: string
+        - name: baseURI
+          in: query
+          required: false
+          description: Specifies a base URI to be used when parsing the SPARQL update operation.
+          type: string
+        - name: using-graph-uri
+          in: query
+          required: false
+          description: One or more named graph URIs to be used as the default graph(s) for retrieving statements.
+          type: boolean
+        - name: using-named-graph-uri
+          in: query
+          required: false
+          description: One or more named graph URIs to be used as named graphs for retrieving statements.
+          type: boolean
+        - name: remove-graph-uri
+          in: query
+          required: false
+          description: One or more named graph URIs to be used as the default graph(s) for removing statements.
+          type: boolean
+        - name: insert-graph-uri
+          in: query
+          required: false
+          description: One or more named graph URIs to be used as the default graph(s) for inserting statements.
+          type: boolean
+      consumes:
+        - application/x-www-form-urlencoded
+        - application/x-rdftransaction
+        - application/rdf+xml
+        - text/plain
+        - text/turtle
+        - text/rdf+n3
+        - text/x-nquads
+        - application/rdf+json
+        - application/trix
+        - application/x-trig
+        - application/x-binary-rdf
+      responses:
+        200:
+          description: OK
+          schema:
+            type: string
+            format: binary
+        204:
+          description: OK
+      produces:
+        - text/plain
+        - application/sparql-results+xml
+        - application/sparql-results+json
+        - application/x-binary-rdf-results-table
+        - application/rdf+xml
+        - text/plain
+        - text/turtle
+        - text/rdf+n3
+        - text/x-nquads
+        - application/rdf+json
+        - application/trix
+        - application/x-trig
+        - application/x-binary-rdf
+    delete:
+        tags:
+          - transactions
+        summary: Abort a transaction
+        description: An active transaction can be aborted by means of a HTTP DELETE request on the transaction resource. This will execute a transaction rollback on the repository and will close the transacion. After executing a DELETE, further operations on the same transaction will result in an error.
+        parameters:
+          - name: repositoryID
+            in: path
+            required: true
+            description: The repository ID
+            type: string
+          - name: transactionID
+            in: path
+            required: true
+            type: string
+            description: The transaction ID
+        responses:
+          204:
+            description: Successfully aborted the defined transaction.


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: #36 .
* Add swagger.yaml based on rdf4j.yaml 9aedafad from graphdb
* https://gitlab.ontotext.com/sdk/graphdb-framework/blob/master/modules/stats/src/main/resources/rdf4j.yaml
