### PR TITLE
Issue eclipse/rdf4j-testsuite#18: Remove testOrderByQueriesAreInterruptable methods

### DIFF
--- a/compliance/server/src/test/java/org/eclipse/rdf4j/repository/http/HTTPStoreConnectionTest.java
+++ b/compliance/server/src/test/java/org/eclipse/rdf4j/repository/http/HTTPStoreConnectionTest.java
@@ -60,13 +60,6 @@ public class HTTPStoreConnectionTest extends RepositoryConnectionTest {
 		return new HTTPRepository(HTTPMemServer.REPOSITORY_URL);
 	}
 
-	@Ignore("temporarily disabled for HTTPRepository")
-	@Test
-	@Override
-	public void testOrderByQueriesAreInterruptable() {
-		System.err.println("temporarily disabled testOrderByQueriesAreInterruptable() for HTTPRepository");
-	}
-
 	@Test
 	public void testContextInTransactionAdd()
 		throws Exception

--- a/compliance/server/src/test/java/org/eclipse/rdf4j/repository/http/RDFSchemaHTTPRepositoryConnectionTest.java
+++ b/compliance/server/src/test/java/org/eclipse/rdf4j/repository/http/RDFSchemaHTTPRepositoryConnectionTest.java
@@ -164,13 +164,6 @@ public class RDFSchemaHTTPRepositoryConnectionTest extends RDFSchemaRepositoryCo
 		System.err.println("temporarily disabled testInferencerTransactionIsolation() for HTTPRepository");
 	}
 
-	@Ignore("temporarily disabled for HTTPRepository")
-	@Test
-	@Override
-	public void testOrderByQueriesAreInterruptable() {
-		System.err.println("temporarily disabled testOrderByQueriesAreInterruptable() for HTTPRepository");
-	}
-
 	@Test
 	@Override
 	public void testAddMalformedLiteralsDefaultConfig()

--- a/compliance/server/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLStoreConnectionTest.java
+++ b/compliance/server/src/test/java/org/eclipse/rdf4j/repository/sparql/SPARQLStoreConnectionTest.java
@@ -292,14 +292,6 @@ public class SPARQLStoreConnectionTest extends RepositoryConnectionTest {
 		// TODO see SES-1776
 	}
 
-	@Ignore
-	@Override
-	public void testOrderByQueriesAreInterruptable()
-		throws Exception
-	{
-		System.err.println("temporarily disabled testOrderByQueriesAreInterruptable() for SPARQLRepository");
-	}
-
 	@Test
 	@Override
 	@Ignore("can not execute test because required data add results in illegal SPARQL syntax")


### PR DESCRIPTION
Signed-off-by: James Leigh <james.leigh@ontotext.com>

This PR addresses GitHub issue: eclipse/rdf4j-testsuite#18 .

* Methods were removed from testsuite in eclipse/rdf4j-testsuite#19
