### PR TITLE
Upgraded JLine dependency

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>org.jline</groupId>
 			<artifactId>jline</artifactId>
-			<version>3.5.1</version>
+			<version>3.6.2</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


This PR addresses GitHub issue: #51  .

Briefly describe the changes proposed in this PR:

* Upgrade JLine library  to 3.6.2  (3.7.0 might be a bit too new, wait for 3.7.1 instead)
