### PR TITLE
Changed Jackson version in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,9 +210,9 @@
 		<slf4j.version>1.7.10</slf4j.version>
 		<logback.version>1.1.2</logback.version>
 		<spring.version>4.2.1.RELEASE</spring.version>
-		<httpclient.version>4.5.2</httpclient.version>
-		<httpcore.version>4.4.4</httpcore.version>
-		<jackson.version>2.8.2</jackson.version>
+		<httpclient.version>4.5.5</httpclient.version>
+		<httpcore.version>4.4.9</httpcore.version>
+		<jackson.version>2.9.5</jackson.version>
 		<last.japicmp.compare.version>2.0</last.japicmp.compare.version>
 	</properties>
 


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


This PR addresses GitHub issue: #58 

Briefly describe the changes proposed in this PR:

* Upgrade Jackson dependency to 2.8.8 (same version as the other RDF4J parts)
