### PR TITLE
eclipse/rdf4j#1023: fix the generation of provider-configuration files

### DIFF
--- a/runtime-osgi/build.xml
+++ b/runtime-osgi/build.xml
@@ -1,43 +1,21 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <project name="rdf4j" basedir=".">
-    <target name="create-service-files">
-	<antcall target="concat-service-file">
-	    <param name="service" value="org.eclipse.rdf4j.query.algebra.evaluation.function.Function"/>
-	</antcall>
-	<antcall target="concat-service-file">
-	    <param name="service" value="org.eclipse.rdf4j.query.parser.QueryParserFactory"/>
-	</antcall>
-	<antcall target="concat-service-file">
-	    <param name="service" value="org.eclipse.rdf4j.query.resultio.BooleanQueryResultParserFactory"/>
-	</antcall>
-	<antcall target="concat-service-file">
-	    <param name="service" value="org.eclipse.rdf4j.query.resultio.BooleanQueryResultWriterFactory"/>
-	</antcall>
-	<antcall target="concat-service-file">
-	    <param name="service" value="org.eclipse.rdf4j.query.resultio.TupleQueryResultParserFactory"/>
-	</antcall>
-	<antcall target="concat-service-file">
-	    <param name="service" value="org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory"/>
-	</antcall>
-	<antcall target="concat-service-file">
-	    <param name="service" value="org.eclipse.rdf4j.repository.config.RepositoryFactory"/>
-	</antcall>
-	<antcall target="concat-service-file">
-	    <param name="service" value="org.eclipse.rdf4j.rio.RDFParserFactory"/>
-	</antcall>
-	<antcall target="concat-service-file">
-	    <param name="service" value="org.eclipse.rdf4j.rio.RDFWriterFactory"/>
-	</antcall>
-	<antcall target="concat-service-file">
-	    <param name="service" value="org.eclipse.rdf4j.sail.config.SailFactory"/>
-	</antcall>
-    </target>
-
-    <target name="concat-service-file">
-	<dirname property="antfile.dir" file="${ant.file}"/>
-	<echo message="META-INF/services/${service}"/>
-	<concat destfile="target/services/META-INF/services/${service}" fixlastline="yes">
-	    <fileset dir="${antfile.dir}/.." includes="**/src/main/resources/META-INF/services/${service}"/>
-	</concat>
-    </target>
+	<target name="enrich-artifact-with-provider-configuration-files">
+		<!-- Unzip the archive containing the provider-configuration files gathered from RDF4J's modules -->
+		<unzip src="${serviceresources.raw.jar}" dest="${serviceresources.raw.dir}" />
+		
+		<!-- Copy the provider-configurations files and remove duplicate entries inside each of them -->
+		<copy todir="${serviceresources.fixed.dir}">
+			<fileset id="serviceFiles" dir="${serviceresources.raw.dir}" includes="META-INF/services/*" />
+			<filterchain>
+				<sortfilter />
+				<uniqfilter />
+			</filterchain>
+		</copy>
+		
+		<!-- Add the fixed provider-configuration files to the main artifact of this project -->
+		<jar destfile="${jarToEnhance}" update="true">
+			<fileset dir="${serviceresources.fixed.dir}" />
+		</jar>
+	</target>
 </project>

--- a/runtime-osgi/pom.xml
+++ b/runtime-osgi/pom.xml
@@ -15,6 +15,14 @@
 	<name>RDF4J: Runtime - OSGi</name>
 	<description>OSGi Runtime dependencies for an RDF4J application</description>
 
+	<properties>
+		<serviceresources.basedir>${project.build.directory}/serviceResources</serviceresources.basedir>
+		<serviceresources.raw.dir>${serviceresources.basedir}/raw</serviceresources.raw.dir>
+		<serviceresources.raw.jar>${serviceresources.raw.dir}/raw-service-resources.jar</serviceresources.raw.jar>
+		<serviceresources.fixed.dir>${serviceresources.basedir}/fixed</serviceresources.fixed.dir>
+		<jarToEnhance>${project.build.directory}/${project.artifactId}-${project.version}.jar</jarToEnhance>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -25,23 +33,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>process-classes</phase>
-						<configuration>
-							<target>
-								<mkdir dir="target/services/META-INF/services" />
-								<ant antfile="build.xml" target="create-service-files" dir="${basedir}" />
-							</target>
-						</configuration>
-						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
@@ -59,10 +50,6 @@
 							org.springframework.*;resolution:=optional,
 							*
 						</Import-Package>
-						<Include-Resource>
-							{maven-resources},
-							META-INF/services=target/services/META-INF/services
-						</Include-Resource>
 						<Embed-Dependency>
 							*;
 							groupId=org.eclipse.rdf4j;
@@ -80,6 +67,56 @@
 						<version>2.4.0</version>
 					</dependency>
 				</dependencies>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>gather-provider-configuration-files</id>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>${project.groupId}:*:*</include>
+								</includes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*</artifact>
+									<includes>
+										<include>META-INF/services/*</include>
+									</includes>
+								</filter>
+							</filters>
+							<transformers>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+							</transformers>
+							<outputFile>${serviceresources.raw.jar}</outputFile>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<id>enrich-main-artifact-with-provider-configuration-files</id>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<ant antfile="build.xml"
+									target="enrich-artifact-with-provider-configuration-files" dir="${basedir}" />
+							</target>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Signed-off-by: Manuel Fiorelli <manuel.fiorelli@gmail.com>


This PR addresses GitHub issue: eclipse/rdf4j#1023 .

The proposed change modifies how provider-configuration files (i.e. the files under `META-INF/services`) are gathered from the various RDF4J modules and stored inside the OSGi runtime bundle.
* the `maven-shade-plugin` is used to gather the content of `META-INF/services` from the different modules of RDF4J:
  * files with the same name are concatenated
  * the files are stored in a jar placed under `target/serviceResources/raw/raw-service-resources.jar`
* the `maven-antrun-plugin` is used to:
  * unpack the jar and place its content under the folder `target/serviceResources/raw`
  * copy all files matching the pattern `META-INF/services/*` to a different folder `target/serviceResources/fixed`, and at same time remove duplicate entries inside each configuration-provider file
 * the fixed provider-configuration files are copied inside the JAR that is the main build artifact.

With regard to my solution, I shall notice that my use of `maven-shade-plugin` is somehow non-standard, since I don't use the plugin to enhance the build artifact directly.

An alternative could be to use ant to scan the classpath for resources matching the pattern `META-INF/services/*`. Looking on the web, I found that the following snippet (inside the POM) can be used to copy the elements on the classapath (e.g. the jars), but not their content:
```
<copy todir="target/" flatten="true">
	<path refid="maven.runtime.classpath" />
</copy>
```
