### PR TITLE
Removed assertj-core 3.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -504,12 +504,6 @@
 				<artifactId>mapdb</artifactId>
 				<version>1.0.8</version>
 			</dependency>
-			<dependency>
-				<groupId>org.assertj</groupId>
-				<artifactId>assertj-core</artifactId>
-				<version>3.10.0</version>
-				<scope>test</scope>
-			</dependency>
 			<!-- Spring framework -->
 			<dependency>
 				<groupId>org.springframework</groupId>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1157 .

Briefly describe the changes proposed in this PR:

* Removed aspectj-core 3.10 from pom, since 3.9.1 is included as well (and CQ-approved)
