### PR TITLE
Updated default version

### DIFF
--- a/assembly/src/main/dist/docker/Dockerfile
+++ b/assembly/src/main/dist/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM tomcat:8.5-jre8-alpine
 MAINTAINER Bart Hanssens (bart.hanssens@bosa.fgov.be)
 
-ARG VERSION="2.4.1"
+ARG VERSION="2.4.2"
 
 ENV JAVA_OPTS="-Xmx2g"
 ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j"


### PR DESCRIPTION
Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>


This PR addresses GitHub issue: eclipse/rdf4j# .

Briefly describe the changes proposed in this PR:

* Default version 2.4.2 instead of 2.4.1
* 
