### PR TITLE
Issues/#1100 namespaces setting

### DIFF
--- a/console/src/main/java/org/eclipse/rdf4j/console/Console.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/Console.java
@@ -49,6 +49,7 @@ import org.eclipse.rdf4j.console.command.Verify;
 import org.eclipse.rdf4j.console.setting.ConsoleSetting;
 import org.eclipse.rdf4j.console.setting.ConsoleWidth;
 import org.eclipse.rdf4j.console.setting.LogLevel;
+import org.eclipse.rdf4j.console.setting.Prefixes;
 import org.eclipse.rdf4j.console.setting.QueryPrefix;
 import org.eclipse.rdf4j.console.setting.ShowPrefix;
 import org.eclipse.rdf4j.console.setting.WorkDir;
@@ -199,6 +200,7 @@ public class Console {
 		// Basic console parameters
 		register(new ConsoleWidth());
 		register(new LogLevel());
+		register(new Prefixes());
 		register(new QueryPrefix());
 		register(new ShowPrefix());
 		register(new WorkDir());

--- a/console/src/main/java/org/eclipse/rdf4j/console/Console.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/Console.java
@@ -266,7 +266,8 @@ public class Console {
 		settingMap.forEach((k,v) -> {
 				String prop = PROP_PREFIX + k;
 				String oldval = props.getProperty(prop, "");
-				String val = v.get() != null ? String.valueOf(v.get()) : oldval;
+				String newval = v.getAsString();
+				String val = (newval != null) ? newval : oldval;
 				
 				if (!val.isEmpty()) {
 					props.setProperty(prop, val);

--- a/console/src/main/java/org/eclipse/rdf4j/console/Util.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/Util.java
@@ -13,8 +13,9 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
-import org.eclipse.rdf4j.model.IRI;
 
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.repository.Repository;
@@ -97,11 +98,22 @@ public class Util {
 		if (value == null) {
 			return null;
 		}
+		if (namespaces.isEmpty()) {
+			return NTriplesUtil.toNTriplesString(value);
+		}
 		if (value instanceof IRI) {
 			IRI uri = (IRI) value;
 			String prefix = namespaces.get(uri.getNamespace());
 			if (prefix != null) {
 				return prefix + ":" + uri.getLocalName();
+			}
+		}
+		if (value instanceof Literal) {
+			Literal lit = (Literal) value;
+			IRI uri = lit.getDatatype();
+			String prefix = namespaces.get(uri.getNamespace());
+			if (prefix != null) {
+				return "\"" + lit.getLabel() + "\"^^" + prefix + ":" + uri.getLocalName();
 			}
 		}
 		return NTriplesUtil.toNTriplesString(value);

--- a/console/src/main/java/org/eclipse/rdf4j/console/Util.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/Util.java
@@ -89,8 +89,8 @@ public class Util {
 	 * Get string representation for a value.
 	 * If the value is an IRI and is part of a known namespace, the prefix will be used to shorten it.
 	 * 
-	 * @param value
-	 * @param namespaces
+	 * @param value value
+	 * @param namespaces mapping (uri,prefix)
 	 * @return string representation
 	 */
 	public static String getPrefixedValue(Value value, Map<String,String> namespaces) {

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
@@ -277,7 +277,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 			return str;
 		}
 		try {
-			consoleIO.writeln("enter multi-line " + queryLn.getName() + " query "
+			consoleIO.writeln("Enter multi-line " + queryLn.getName() + " query "
 							+ "(terminate with line containing single '.')");
 			return consoleIO.readMultiLineInput();
 		} catch (IOException e) {

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/QueryEvaluator.java
@@ -408,7 +408,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	 * Get output stream for a file, or for the console output if path is null
 	 * 
 	 * @param path file path or null
-	 * @return file or console outputstream
+	 * @return file or console output stream
 	 * @throws IOException
 	 */
 	private OutputStream getOutputStream(Path path) throws IOException {
@@ -461,7 +461,7 @@ public abstract class QueryEvaluator extends ConsoleCommand {
 	}
 
 	/**
-	 * Add namespaces prefixes to SPARQL or SERQL query from repository connection
+	 * Add namespace prefixes to SPARQL or SERQL query from repository connection
 	 * 
 	 * @param queryString query string
 	 * @return query string with prefixes

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
@@ -9,7 +9,6 @@ package org.eclipse.rdf4j.console.command;
 
 import java.util.Map;
 import java.util.Objects;
-import org.eclipse.rdf4j.common.text.StringUtil;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleParameters;

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.console.command;
 
 import java.util.Map;
 import java.util.Objects;
+import org.eclipse.rdf4j.common.text.StringUtil;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleParameters;
@@ -72,22 +73,27 @@ public class SetParameters extends ConsoleCommand {
 	
 	@Override
 	public void execute(String... tokens) {
-		if (tokens.length == 1) {
-			for (String setting: settings.keySet()) {
-				showSetting(setting);
-			}
-		} else if (tokens.length == 2) {
-			String param = tokens[1];
-			int eqIdx = param.indexOf('=');
-			if (eqIdx < 0) {
-				showSetting(param);
-			} else {
-				String key = param.substring(0, eqIdx);
-				String value = param.substring(eqIdx + 1);
-				setParameter(key, value);
-			}
-		} else {
-			consoleIO.writeln(getHelpLong());
+		switch(tokens.length) {
+			case 0:
+				consoleIO.writeln(getHelpLong());
+				break;
+			case 1:
+				for (String setting: settings.keySet()) {
+					showSetting(setting);
+				}
+				break;
+			default:
+				String param = tokens[1];
+				int eqIdx = param.indexOf('=');
+				if (eqIdx < 0) {
+					showSetting(param);
+				} else {
+					String key = param.substring(0, eqIdx);
+					// FIXME: somewhat ugly, join back together to set parameter which may contain spaces
+					String values = String.join(" ", tokens);
+					eqIdx = values.indexOf('=');
+					setParameter(key, values.substring(eqIdx + 1));
+				}
 		}
 	}
 
@@ -103,7 +109,7 @@ public class SetParameters extends ConsoleCommand {
 		if (setting != null) {
 			consoleIO.writeln(key + ": " + setting.getAsString());
 		} else {
-			consoleIO.writeError("unknown parameter: " + key);
+			consoleIO.writeError("Unknown parameter: " + key);
 		}
 	}
 
@@ -127,7 +133,7 @@ public class SetParameters extends ConsoleCommand {
 				consoleIO.writeError(iae.getMessage());
 			}
 		} else {
-			consoleIO.writeError("unknown parameter: " + key);
+			consoleIO.writeError("Unknown parameter: " + key);
 		}
 	}
 }

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/TupleAndGraphQueryEvaluator.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/TupleAndGraphQueryEvaluator.java
@@ -7,18 +7,13 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-
-import org.eclipse.rdf4j.common.iteration.Iterations;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleParameters;
 import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.setting.ConsoleSetting;
-
-import org.eclipse.rdf4j.model.Namespace;
 
 import org.eclipse.rdf4j.query.GraphQueryResult;
 import org.eclipse.rdf4j.query.MalformedQueryException;
@@ -38,6 +33,8 @@ import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 
 /**
+ * Evaluator tuple and graph queries
+ * 
  * @author dale
  */
 public class TupleAndGraphQueryEvaluator {
@@ -191,7 +188,7 @@ public class TupleAndGraphQueryEvaluator {
 			writer.endRDF();
 		}
 		long endTime = System.nanoTime();
-		consoleIO.writeln(resultCount + " results (" + (endTime - startTime) / 1000000 + " ms)");
+		consoleIO.writeln(resultCount + " results (" + (endTime - startTime) / 1_000_000 + " ms)");
 	}
 	
 	/**
@@ -221,8 +218,7 @@ public class TupleAndGraphQueryEvaluator {
 			writer.endQueryResult();
 		}
 		long endTime = System.nanoTime();
-		consoleIO.writeln("Query evaluated in " + (endTime - startTime) / 1000000 + " ms");
-		
+		consoleIO.writeln("Query evaluated in " + (endTime - startTime) / 1_000_000 + " ms");	
 	}
 
 	/**
@@ -246,6 +242,6 @@ public class TupleAndGraphQueryEvaluator {
 		}
 
 		long endTime = System.nanoTime();
-		consoleIO.writeln("Update executed in " + (endTime - startTime) / 1000000 + " ms");		
+		consoleIO.writeln("Update executed in " + (endTime - startTime) / 1_000_000 + " ms");		
 	}
 }

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/TupleAndGraphQueryEvaluator.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/TupleAndGraphQueryEvaluator.java
@@ -17,8 +17,6 @@ import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleParameters;
 import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.setting.ConsoleSetting;
-import org.eclipse.rdf4j.console.setting.ConsoleWidth;
-import org.eclipse.rdf4j.console.setting.ShowPrefix;
 
 import org.eclipse.rdf4j.model.Namespace;
 
@@ -143,10 +141,6 @@ public class TupleAndGraphQueryEvaluator {
 					resultCount++;
 				}
 			} else {
-				Collection<Namespace> namespaces = Iterations.asList(con.getNamespaces());
-				for (Namespace ns: namespaces) {
-					writer.handleNamespace(ns.getPrefix(), ns.getName());
-				}
 				writer.startDocument();
 				writer.startHeader();
 				writer.startQueryResult(bindingNames);
@@ -188,10 +182,6 @@ public class TupleAndGraphQueryEvaluator {
 
 			con.setParserConfig(nonVerifyingParserConfig);
 
-			Collection<Namespace> namespaces = Iterations.asList(con.getNamespaces());
-			for (Namespace ns: namespaces) {
-				writer.handleNamespace(ns.getPrefix(), ns.getName());
-			}
 			writer.startRDF();
 
 			while (res.hasNext()) {

--- a/console/src/main/java/org/eclipse/rdf4j/console/setting/NameSpaces.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/setting/NameSpaces.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.console.setting;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.impl.SimpleNamespace;
+import org.eclipse.rdf4j.model.util.URIUtil;
+
+import org.eclipse.rdf4j.model.vocabulary.DCAT;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.ORG;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.ROV;
+import org.eclipse.rdf4j.model.vocabulary.SKOS;
+import org.eclipse.rdf4j.model.vocabulary.VCARD4;
+import org.eclipse.rdf4j.model.vocabulary.VOID;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+
+/**
+ * Namespace prefix setting
+ * 
+ * @author Bart Hanssens
+ */
+public class NameSpaces extends ConsoleSetting<Set<Namespace>> {
+	public final static String NAME = "ns";
+	
+	public final static Set<Namespace> DEFAULT = new HashSet<>();
+	static {
+		DEFAULT.add(DCAT.NS);
+		DEFAULT.add(DCTERMS.NS);
+		DEFAULT.add(FOAF.NS);		
+		DEFAULT.add(ORG.NS);
+		DEFAULT.add(OWL.NS);
+		DEFAULT.add(RDF.NS);
+		DEFAULT.add(RDFS.NS);
+		DEFAULT.add(ROV.NS);
+		DEFAULT.add(SKOS.NS);
+		DEFAULT.add(VCARD4.NS);
+		DEFAULT.add(VOID.NS);
+		DEFAULT.add(XMLSchema.NS);
+	}
+
+	@Override
+	public String getHelpLong() {
+		return "set ns                         Set the namespace prefixes\n";
+	}
+	
+	/**
+	 * Constructor
+	 * 
+	 * Default set of namespaces are well-known ones
+	 */
+	public NameSpaces() {
+		super(DEFAULT);
+	}
+	
+	/**
+	 * Constructor
+	 * 
+	 * @param initValue
+	 */
+	public NameSpaces(Set<Namespace> initValue) {
+		super(initValue);
+	}
+	
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public void clear() {
+		set(Collections.EMPTY_SET);
+	}
+
+	@Override
+	public String getAsString() {
+		return get().stream()
+					.map(ns -> { return ns.getPrefix() + " " + ns.getName(); })
+					.collect(Collectors.joining(","));
+	}
+
+	/**
+	 * Set one namespace from a string, using one whitespace to separate prefix and namespace URI
+	 * E.g.   'dcterms http://purl.org/dc/terms/'
+	 * 
+	 * @param namespace 
+	 */
+	private void setOneFromString(String namespace) {
+		String[] parts = namespace.split(" ");
+		if (parts.length != 2) {
+			throw new IllegalArgumentException("Error parsing namespace: " + namespace);
+		}
+		if (!URIUtil.isValidURIReference(parts[1])) {
+			throw new IllegalArgumentException("Error parsing namespace  URI: " + parts[1]);
+		}
+		get().add(new SimpleNamespace(parts[0], parts[1]));
+	}
+
+	@Override
+	public void setFromString(String value) throws IllegalArgumentException {
+		if (value == null || value.isEmpty()) {
+			throw new IllegalArgumentException("Empty or null namespace value");
+		}
+		if (value.equals("<none>")) {
+			clear();
+			return;
+		}
+		if (value.equals("<default>")) {
+			set(DEFAULT);
+		}
+		
+		String[] namespaces = value.split(",");
+		for (String namespace: namespaces) {
+			setOneFromString(namespace);
+		}
+	}
+}

--- a/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
@@ -92,6 +92,7 @@ public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 	public String getAsString() {
 		return get().stream()
 					.map(ns -> { return ns.getPrefix() + " " + ns.getName(); })
+					.sorted()
 					.collect(Collectors.joining(","));
 	}
 

--- a/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
@@ -119,9 +119,10 @@ public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 		}
 		if (parts[1].equals("<none>")) {
 			clearNamespace(parts[0]);
+			return;
 		}
 		if (!URIUtil.isValidURIReference(parts[1])) {
-			throw new IllegalArgumentException("Error parsing namespace  URI: " + parts[1]);
+			throw new IllegalArgumentException("Error parsing namespace URI: " + parts[1]);
 		}
 		get().add(new SimpleNamespace(parts[0], parts[1]));
 	}

--- a/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
@@ -35,7 +35,7 @@ import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
  * @author Bart Hanssens
  */
 public class Prefixes extends ConsoleSetting<Set<Namespace>> {
-	public final static String NAME = "ns";
+	public final static String NAME = "prefixes";
 	
 	public final static Set<Namespace> DEFAULT = new HashSet<>();
 	static {
@@ -123,6 +123,7 @@ public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 		}
 		if (value.equals("<default>")) {
 			set(DEFAULT);
+			return;
 		}
 		
 		String[] namespaces = value.split(",");

--- a/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
@@ -51,13 +51,14 @@ public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 		DEFAULT.add(VCARD4.NS);
 		DEFAULT.add(VOID.NS);
 		DEFAULT.add(XMLSchema.NS);
-	}
+	} 
 
 	@Override
 	public String getHelpLong() {
-		return "set prefixes=<default> Set the prefixes to a default list of prefixes\n" +
-			   "set prefixes=<none>    Clear list of prefixes\n";
-		
+		return "set prefixes=<default>         Set the prefixes to a default list of prefixes\n" +
+			   "    prefixes=<none>            Remove all namespace prefixes\n" +
+			   "	prefixes=prefix ns-url     Set prefix for namespace\n" +
+			   "	prefixes=prefix <none>     Remove namespace prefix\n";	
 	}
 	
 	/**
@@ -85,7 +86,16 @@ public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 
 	@Override
 	public void clear() {
-		set(Collections.EMPTY_SET);
+		get().clear();
+	}
+	
+	/**
+	 * Remove the namespace with specified prefix
+	 * 
+	 * @param prefix 
+	 */
+	private void clearNamespace(String prefix) {
+		get().removeIf(ns -> ns.getPrefix().equals(prefix));
 	}
 
 	@Override
@@ -97,15 +107,18 @@ public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 	}
 
 	/**
-	 * Set one namespace from a string, using one whitespace to separate prefix and namespace URI
+	 * Set a namespace from a string, using one whitespace to separate prefix and namespace URI
 	 * E.g.   'dcterms http://purl.org/dc/terms/'
 	 * 
 	 * @param namespace 
 	 */
-	private void setOneFromString(String namespace) {
+	private void setNamespace(String namespace) {
 		String[] parts = namespace.split(" ");
 		if (parts.length != 2) {
 			throw new IllegalArgumentException("Error parsing namespace: " + namespace);
+		}
+		if (parts[1].equals("<none>")) {
+			clearNamespace(parts[0]);
 		}
 		if (!URIUtil.isValidURIReference(parts[1])) {
 			throw new IllegalArgumentException("Error parsing namespace  URI: " + parts[1]);
@@ -129,7 +142,7 @@ public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 		
 		String[] namespaces = value.split(",");
 		for (String namespace: namespaces) {
-			setOneFromString(namespace);
+			setNamespace(namespace);
 		}
 	}
 }

--- a/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
@@ -34,7 +34,7 @@ import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
  * 
  * @author Bart Hanssens
  */
-public class NameSpaces extends ConsoleSetting<Set<Namespace>> {
+public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 	public final static String NAME = "ns";
 	
 	public final static Set<Namespace> DEFAULT = new HashSet<>();
@@ -55,7 +55,9 @@ public class NameSpaces extends ConsoleSetting<Set<Namespace>> {
 
 	@Override
 	public String getHelpLong() {
-		return "set ns                         Set the namespace prefixes\n";
+		return "set prefixes=<default> Set the prefixes to a default list of prefixes\n" +
+			   "set prefixes=<none>    Clear list of prefixes\n";
+		
 	}
 	
 	/**
@@ -63,7 +65,7 @@ public class NameSpaces extends ConsoleSetting<Set<Namespace>> {
 	 * 
 	 * Default set of namespaces are well-known ones
 	 */
-	public NameSpaces() {
+	public Prefixes() {
 		super(DEFAULT);
 	}
 	
@@ -72,7 +74,7 @@ public class NameSpaces extends ConsoleSetting<Set<Namespace>> {
 	 * 
 	 * @param initValue
 	 */
-	public NameSpaces(Set<Namespace> initValue) {
+	public Prefixes(Set<Namespace> initValue) {
 		super(initValue);
 	}
 	

--- a/console/src/main/java/org/eclipse/rdf4j/console/util/ConsoleQueryResultWriter.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/util/ConsoleQueryResultWriter.java
@@ -8,8 +8,10 @@
 package org.eclipse.rdf4j.console.util;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.rdf4j.common.text.StringUtil;
 

--- a/console/src/main/java/org/eclipse/rdf4j/console/util/ConsoleQueryResultWriter.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/util/ConsoleQueryResultWriter.java
@@ -8,10 +8,8 @@
 package org.eclipse.rdf4j.console.util;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.rdf4j.common.text.StringUtil;
 
@@ -35,6 +33,7 @@ public class ConsoleQueryResultWriter extends AbstractQueryResultWriter {
 	private final ConsoleIO consoleIO;
 	private final int consoleWidth;
 	private final Map<String,String> namespaces = new HashMap<>();
+	private List<String> bindingNames;
 	private int columnWidth;
 	private String separatorLine = "";
 	private String header = "";
@@ -73,14 +72,13 @@ public class ConsoleQueryResultWriter extends AbstractQueryResultWriter {
 
 	@Override
 	public void startHeader() throws QueryResultHandlerException {
-		consoleIO.writeln(separatorLine);
-		consoleIO.writeln(header);
-		consoleIO.writeln(separatorLine);
 	}
 
 	@Override
 	public void endHeader() throws QueryResultHandlerException {
-		//
+		consoleIO.writeln(separatorLine);
+		consoleIO.writeln(header);
+		consoleIO.writeln(separatorLine);
 	}
 
 	@Override
@@ -95,6 +93,7 @@ public class ConsoleQueryResultWriter extends AbstractQueryResultWriter {
 
 	@Override
 	public void startQueryResult(List<String> bindingNames) throws TupleQueryResultHandlerException {
+		this.bindingNames = bindingNames;
 		int columns = bindingNames.size();
 		columnWidth = (consoleWidth - 1) / columns  - 3;
 
@@ -127,7 +126,7 @@ public class ConsoleQueryResultWriter extends AbstractQueryResultWriter {
 	public void handleSolution(BindingSet bindingSet) throws TupleQueryResultHandlerException {
 		StringBuilder builder = new StringBuilder(512);
 						
-		for (String bindingName : bindingSet.getBindingNames()) {
+		for (String bindingName : bindingNames) {
 			Value value = bindingSet.getValue(bindingName);
 			String valueStr = Util.getPrefixedValue(value, namespaces);
 			builder.append("| ").append(valueStr);

--- a/console/src/test/java/org/eclipse/rdf4j/console/command/SetParametersTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/command/SetParametersTest.java
@@ -7,9 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.After;
 import org.junit.Before;
@@ -19,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,6 +26,15 @@ import org.eclipse.rdf4j.console.setting.LogLevel;
 import org.eclipse.rdf4j.console.setting.QueryPrefix;
 import org.eclipse.rdf4j.console.setting.ShowPrefix;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Test setting parameters
+ * 
+ * @author Bart Hanssens
+ */
 public class SetParametersTest extends AbstractCommandTest {
 	SetParameters setParameters;
 	
@@ -62,7 +69,7 @@ public class SetParametersTest extends AbstractCommandTest {
 	public void testUnknownParametersAreErrors() {
 		setParameters.execute("set", "unknown");
 
-		verify(mockConsoleIO).writeError("unknown parameter: unknown");
+		verify(mockConsoleIO).writeError("Unknown parameter: unknown");
 		verifyNoMoreInteractions(mockConsoleIO);
 	}
 


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1100 .

Briefly describe the changes proposed in this PR:

* Added a namespace prefixes setting, used when querying and showing results
* Prefixes also used to shorten `Literal` datatype IRIs 
* A list of frequently used prefixes (dcterms: ...) is provided as default setting
* Values will be saved to properties file when exiting
* Removed code for getting namespace prefixes from repo connection (did this actually work ?)

Some examples
* set prefixes=<none>  (clear everything)
* set prefixes=<default>  (use defaults)
* set prefixes=dcterms <none>  (clear one)
* set prefixes=dcterms http://purl.org/dc/terms  (set one)

Still to do: some cleanup and tests.

Syntax is somewhat ugly (with the '='), but other legacy setting are using this as well, so another enhancement would be to make "=" optional.  