### PR TITLE
Upgrade to latest Mockito 2

### DIFF
--- a/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/command/AbstractCommandTest.java
@@ -16,7 +16,6 @@ import java.io.StringReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
 import org.eclipse.rdf4j.RDF4JException;

--- a/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/command/ConvertTest.java
@@ -11,9 +11,7 @@ import com.github.jsonldjava.utils.JsonUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 
 import org.eclipse.rdf4j.RDF4JException;
 

--- a/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/command/DropTest.java
@@ -8,8 +8,8 @@
 package org.eclipse.rdf4j.console.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;

--- a/console/src/test/java/org/eclipse/rdf4j/console/command/FederateTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/command/FederateTest.java
@@ -10,7 +10,7 @@ package org.eclipse.rdf4j.console.command;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
@@ -29,9 +29,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.never;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/pom.xml
+++ b/pom.xml
@@ -467,10 +467,9 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<!-- needs extra dependencies: objenesis & hamcrest -->
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>1.10.19</version>
+				<version>2.23.4</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
@@ -479,7 +478,6 @@
 				<version>3.9.1</version>
 				<scope>test</scope>
 			</dependency>
-
 			<dependency>
 				<groupId>com.github.jsonld-java</groupId>
 				<artifactId>jsonld-java</artifactId>
@@ -817,6 +815,9 @@
 							<rules>
 								<enforceBytecodeVersion>
 									<maxJdkVersion>1.8</maxJdkVersion>
+									<ignoreClasses>
+										<ignoreClass>META-INF/**/module-info</ignoreClass>
+									</ignoreClasses>
 									<excludes>
 										<exclude>org.apache.logging.log4j:log4j-api</exclude>
 										<exclude>org.elasticsearch:elasticsearch</exclude>
@@ -831,7 +832,7 @@
 					<dependency>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.0-beta-6</version>
+						<version>1.0</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
+++ b/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/statements/TestStatementsController.java
@@ -16,7 +16,9 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.junit.Test;
+
 import org.mockito.Mockito;
+
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;

--- a/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
+++ b/server-spring/src/test/java/org/eclipse/rdf4j/http/server/repository/transaction/TestActiveTransactionRegistry.java
@@ -12,7 +12,9 @@ import java.util.UUID;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.junit.Before;
+
 import org.mockito.Mockito;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestExploreServlet.java
+++ b/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestExploreServlet.java
@@ -8,6 +8,7 @@
 package org.eclipse.rdf4j.workbench.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -25,6 +26,7 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.eclipse.rdf4j.workbench.commands.ExploreServlet.ResultCursor;
 import org.eclipse.rdf4j.workbench.util.TupleResultBuilder;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestInfoServlet.java
+++ b/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestInfoServlet.java
@@ -7,7 +7,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.workbench.commands;
 
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestQueryServlet.java
+++ b/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestQueryServlet.java
@@ -8,9 +8,10 @@
 package org.eclipse.rdf4j.workbench.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,7 +22,6 @@ import javax.servlet.ServletException;
 
 import org.eclipse.rdf4j.RDF4JException;
 import org.eclipse.rdf4j.common.io.ResourceUtil;
-import org.eclipse.rdf4j.repository.http.HTTPRepository;
 import org.eclipse.rdf4j.workbench.exceptions.BadRequestException;
 import org.eclipse.rdf4j.workbench.util.QueryStorage;
 import org.eclipse.rdf4j.workbench.util.WorkbenchRequest;
@@ -149,8 +149,7 @@ public class TestQueryServlet {
 		when(request.isParameterPresent(QueryServlet.REF)).thenReturn(true);
 		when(request.getParameter(QueryServlet.REF)).thenReturn("id");
 		QueryStorage storage = mock(QueryStorage.class);
-		when(storage.getQueryText(any(HTTPRepository.class), anyString(), eq("test save name"))).thenReturn(
-				longQuery);
+		when(storage.getQueryText(any(), anyString(), eq("test save name"))).thenReturn(longQuery);
 		servlet.substituteQueryStorage(storage);
 		assertThat(servlet.getQueryText(request)).isEqualTo(longQuery);
 	}

--- a/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestRemoveServlet.java
+++ b/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/TestRemoveServlet.java
@@ -8,7 +8,8 @@
 package org.eclipse.rdf4j.workbench.commands;
 
 import static org.eclipse.rdf4j.workbench.base.TransformationServlet.CONTEXT;
-import static org.mockito.Matchers.eq;
+
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/workbench/src/test/java/org/eclipse/rdf4j/workbench/util/TestValueDecoder.java
+++ b/workbench/src/test/java/org/eclipse/rdf4j/workbench/util/TestValueDecoder.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.workbench.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,6 +23,7 @@ import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.workbench.exceptions.BadRequestException;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1214 .

Briefly describe the changes proposed in this PR:

* Use Mockito 2.23 instead of 1.x
* Replacing deprecated Mockito 1.x imports by 2.x counterparts
* Remove unused imports
* Ignore JDK 9 module-info.java in third party code (Mockito now uses bytebuddy) when enforcing JDK 8 code
