### PR TITLE
Remove unused cglib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,12 +407,6 @@
 					</exclusion>
 				</exclusions>
 			</dependency>
-
-			<dependency>
-				<groupId>cglib</groupId>
-				<artifactId>cglib</artifactId>
-				<version>3.1</version>
-			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -58,11 +58,6 @@
 		</dependency>
 		
 		<dependency>
-			<groupId>cglib</groupId>
-			<artifactId>cglib</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1217 .

Briefly describe the changes proposed in this PR:

* Remove unused cglib from main pom.xml and server-spring pom.xml (spring already includes cglib)
