### PR TITLE
Issues/#1102 create templates

### DIFF
--- a/console/src/main/java/org/eclipse/rdf4j/console/Util.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/Util.java
@@ -12,6 +12,7 @@ import java.net.URISyntaxException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Map;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -117,5 +118,55 @@ public class Util {
 			}
 		}
 		return NTriplesUtil.toNTriplesString(value);
+	}
+	
+	/**
+	 * Join an array of values + separator, starting new line(s) when the joined values exceed the width. 
+	 * Primarily used for displaying formatted help (e.g namespaces, config files) to the console.
+	 * 
+	 * @param width max column width
+	 * @param padLen number of leading spaces on each new line 
+	 * @param padFirst also pad the first line
+	 * @param values array of values
+	 * @param sep value separator
+	 * @return list of values as a formatted string, or empty
+	 */
+	public static String joinFormatted(int width, int padLen, boolean padFirst, String[] values, String sep) {
+		if (values.length == 0) {
+			return "";
+		}
+	
+		char[] spaces = new char[padLen];
+		Arrays.fill(spaces, ' ');
+		String padding = new String(spaces);
+		
+		StringBuilder buf = new StringBuilder();
+		if (padFirst) {
+			buf.append(padding);
+		}
+		
+		int pos = buf.length();
+		int sepLen = sep.length();
+		
+		for(String value: values) {
+			int valLen = value.length();
+
+			// too large, start new padded line
+			if (pos + valLen > width) {
+				buf.append("\n").append(padding);
+				pos = padLen;
+			}
+			buf.append(value);
+			pos += valLen;
+			
+			// don't add a separator if that would exceed the width
+			if (pos + sepLen <= width) {
+				buf.append(sep);
+			}
+			pos += sepLen;
+		}
+		
+		String s = buf.toString();
+		return s.endsWith(sep) ? s.substring(0, s.length() - sepLen) : s;
 	}
 }

--- a/console/src/main/java/org/eclipse/rdf4j/console/Util.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/Util.java
@@ -12,7 +12,6 @@ import java.net.URISyntaxException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Map;
 
 import org.eclipse.rdf4j.model.IRI;
@@ -123,6 +122,7 @@ public class Util {
 	/**
 	 * Format a string of values, starting new line(s) when the joined values exceed the width. 
 	 * Primarily used for displaying formatted help (e.g namespaces, config files) to the console.
+	 * To be replaced by a commons text method
 	 * 
 	 * @param width maximum column width
 	 * @param padding left padding
@@ -130,6 +130,7 @@ public class Util {
 	 * @param separator value separator
 	 * @return list of values as a formatted string, or empty
 	 */
+	@Deprecated
 	public static String formatToWidth(int width, String padding, String str, String separator) {
 		if (str.isEmpty()) {
 			return "";

--- a/console/src/main/java/org/eclipse/rdf4j/console/Util.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/Util.java
@@ -121,52 +121,45 @@ public class Util {
 	}
 	
 	/**
-	 * Join an array of values + separator, starting new line(s) when the joined values exceed the width. 
+	 * Format a string of values, starting new line(s) when the joined values exceed the width. 
 	 * Primarily used for displaying formatted help (e.g namespaces, config files) to the console.
 	 * 
-	 * @param width max column width
-	 * @param padLen number of leading spaces on each new line 
-	 * @param padFirst also pad the first line
-	 * @param values array of values
-	 * @param sep value separator
+	 * @param width maximum column width
+	 * @param padding left padding
+	 * @param str joined string
+	 * @param separator value separator
 	 * @return list of values as a formatted string, or empty
 	 */
-	public static String joinFormatted(int width, int padLen, boolean padFirst, String[] values, String sep) {
-		if (values.length == 0) {
+	public static String formatToWidth(int width, String padding, String str, String separator) {
+		if (str.isEmpty()) {
 			return "";
 		}
-	
-		char[] spaces = new char[padLen];
-		Arrays.fill(spaces, ' ');
-		String padding = new String(spaces);
 		
-		StringBuilder buf = new StringBuilder();
-		if (padFirst) {
-			buf.append(padding);
+		int padLen = padding.length();
+		int strLen = str.length();
+		int sepLen = separator.length();
+		
+		if (strLen + padLen <= width) {
+			return padding + str;
 		}
 		
-		int pos = buf.length();
-		int sepLen = sep.length();
+		String[] values = str.split(separator);
+		StringBuilder builder = new StringBuilder(strLen + 4 * padLen + 8 * sepLen);
+
+		int colpos = width; // force start on new line
 		
 		for(String value: values) {
-			int valLen = value.length();
-
-			// too large, start new padded line
-			if (pos + valLen > width) {
-				buf.append("\n").append(padding);
-				pos = padLen;
+			int len = value.length();
+			if (colpos + sepLen + len <= width) {
+				builder.append(separator);
+			} else {
+				builder.append("\n").append(padding);
+				colpos = padLen;
 			}
-			buf.append(value);
-			pos += valLen;
-			
-			// don't add a separator if that would exceed the width
-			if (pos + sepLen <= width) {
-				buf.append(sep);
-			}
-			pos += sepLen;
+			builder.append(value);
+			colpos += len;
 		}
-		
-		String s = buf.toString();
-		return s.endsWith(sep) ? s.substring(0, s.length() - sepLen) : s;
+		// don't return initial newline
+		return builder.substring(1);
 	}
 }

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
@@ -79,7 +79,7 @@ public class Create extends ConsoleCommand {
 			+ "    memory-spin, memory-spin-rdfs, memory-spin-rdfs-lucene\n"
 			+ "    native-rdfs, native-rdfs-dt, native-lucene, native-customrule\n"
 			+ "    native-spin, native-spin-rdfs, native-spin-rdfs-lucene\n"
-			+ "  template-dir: \n" 
+			+ "  template-dir (" + templatesDir + "):\n" 
 			+ getUserTemplates();
 	}
 
@@ -109,18 +109,18 @@ public class Create extends ConsoleCommand {
 	 * @return ordered array of names
 	 */
 	private String getUserTemplates() {
-		if (this.templatesDir == null || !this.templatesDir.isDirectory()) {
+		if (templatesDir == null || !templatesDir.exists() || !templatesDir.isDirectory()) {
 			return "";
 		}
 		try {
-			String[] files = Files.walk(this.templatesDir.toPath())
+			String[] files = Files.walk(templatesDir.toPath())
 								.filter(Files::isRegularFile)
 								.map(f -> f.getFileName().toString()).filter(s -> s.endsWith(FILE_EXT))
 								.map(s -> s.substring(0, s.length() - FILE_EXT.length()))
-								.sorted()
-								.collect(Collectors.toSet()).toArray(new String[0]);
+								.sorted().toArray(String[]::new);
 			return Util.joinFormatted(80, 4, true, files, ", ");
 		} catch (IOException ioe) {
+			LOGGER.error("Failed to read templates directory repository ", ioe);
 			return "";
 		}
 	}
@@ -134,7 +134,7 @@ public class Create extends ConsoleCommand {
 	private void createRepository(final String templateName) throws IOException {
 		try {
 			// FIXME: remove assumption of .ttl extension
-			final String templateFileName = templateName + ".ttl";
+			final String templateFileName = templateName + FILE_EXT;
 			final File templateFile = new File(templatesDir, templateFileName);
 			
 			InputStream templateStream = createTemplateStream(templateName, templateFileName, templatesDir,

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
@@ -113,12 +113,12 @@ public class Create extends ConsoleCommand {
 			return "";
 		}
 		try {
-			String[] files = Files.walk(templatesDir.toPath())
+			String files = Files.walk(templatesDir.toPath())
 								.filter(Files::isRegularFile)
 								.map(f -> f.getFileName().toString()).filter(s -> s.endsWith(FILE_EXT))
 								.map(s -> s.substring(0, s.length() - FILE_EXT.length()))
-								.sorted().toArray(String[]::new);
-			return Util.joinFormatted(80, 4, true, files, ", ");
+								.sorted().collect(Collectors.joining(", "));
+			return Util.formatToWidth(80, "    ", files, ", ");
 		} catch (IOException ioe) {
 			LOGGER.error("Failed to read templates directory repository ", ioe);
 			return "";

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/Create.java
@@ -31,7 +31,6 @@ import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleState;
 import org.eclipse.rdf4j.console.LockRemover;
 import org.eclipse.rdf4j.console.Util;
-import org.eclipse.rdf4j.console.setting.ConsoleWidth;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;

--- a/console/src/test/java/org/eclipse/rdf4j/console/UtilTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/UtilTest.java
@@ -75,16 +75,16 @@ public class UtilTest {
 	}
 	
 	@Test
-	public final void testJoinFormatted() {
-		String[] values = { "one", "two", "three", "four", "five", "six", "seven", "eight" };
+	public final void testFormatToWidth() {
+		String str = "one, two, three, four, five, six, seven, eight";
 		
 		String expect = " one, two\n" +
-						" three, \n" +
-						" four, \n" +
+						" three\n" +
+						" four\n" +
 						" five, six\n" +
-						" seven, \n" +
+						" seven\n" +
 						" eight";
-		String fmt = Util.joinFormatted(10, 1, true, values, ", ");
+		String fmt = Util.formatToWidth(10, " ", str, ", ");
 		System.err.println(fmt);
 		assertTrue("Format not OK", expect.equals(fmt));
 	}

--- a/console/src/test/java/org/eclipse/rdf4j/console/UtilTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/UtilTest.java
@@ -73,4 +73,19 @@ public class UtilTest {
 		} catch(IllegalArgumentException expected) {
 		}
 	}
+	
+	@Test
+	public final void testJoinFormatted() {
+		String[] values = { "one", "two", "three", "four", "five", "six", "seven", "eight" };
+		
+		String expect = " one, two\n" +
+						" three, \n" +
+						" four, \n" +
+						" five, six\n" +
+						" seven, \n" +
+						" eight";
+		String fmt = Util.joinFormatted(10, 1, true, values, ", ");
+		System.err.println(fmt);
+		assertTrue("Format not OK", expect.equals(fmt));
+	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1102 .

Briefly describe the changes proposed in this PR:

* Show the list of available configuration templates on the console (built-in + user defined in app config templates directory)
* Added a convenience method for reformatting a concatenated string (can be reused for better displaying e.g. namespace prefixes setting)

Output when entering "create" command on the console looks like:

```
Usage:
create <template>   Create a new repository using this configuration template
  built-in: 
    memory, native, remote, sparql
    memory-rdfs, memory-rdfs-dt, memory-lucene, memory-customrule
    memory-spin, memory-spin-rdfs, memory-spin-rdfs-lucene
    native-rdfs, native-rdfs-dt, native-lucene, native-customrule
    native-spin, native-spin-rdfs, native-spin-rdfs-lucene
  template-dir (C:\Users\Bart.Hanssens\AppData\Roaming\RDF4J\Console\templates):
    custom-template1, custom-template2 
```
