### PR TITLE
Display namespace prefixes as list instead of concatenated string

### DIFF
--- a/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
@@ -7,8 +7,10 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleParameters;
@@ -106,7 +108,16 @@ public class SetParameters extends ConsoleCommand {
 		
 		ConsoleSetting setting = settings.get(str);
 		if (setting != null) {
-			consoleIO.writeln(key + ": " + setting.getAsString());
+			String s = setting.getAsString();
+			// quick and dirty wrapping of too long values
+			if ((s.length() > 80 - 10) && s.contains(",")) {
+				StringBuilder builder = new StringBuilder();
+				for (String val: s.split(",")) {
+					builder.append("\n    ").append(val);
+				}
+				s = builder.toString();
+			}
+			consoleIO.writeln(key + ": " + s);
 		} else {
 			consoleIO.writeError("Unknown parameter: " + key);
 		}


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1258 .

Briefly describe the changes proposed in this PR:

* Split after semicolon and display on new line
