### PR TITLE
Issues/#1259 namespaces default

### DIFF
--- a/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
@@ -103,7 +103,7 @@ public class SetParameters extends ConsoleCommand {
 	 */
 	private void showSetting(String key) {
 		String str = key.toLowerCase();
-		
+	
 		ConsoleSetting setting = settings.get(str);
 		if (setting != null) {
 			String s = setting.getAsString();
@@ -115,7 +115,7 @@ public class SetParameters extends ConsoleCommand {
 				}
 				s = builder.toString();
 			}
-			consoleIO.writeln(key + ": " + s);
+			consoleIO.writeln(key + ": " + s);			
 		} else {
 			consoleIO.writeError("Unknown parameter: " + key);
 		}

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
@@ -103,8 +103,8 @@ public class SetParameters extends ConsoleCommand {
 	 */
 	private void showSetting(String key) {
 		String str = key.toLowerCase();
-	
 		ConsoleSetting setting = settings.get(str);
+
 		if (setting != null) {
 			String s = setting.getAsString();
 			// quick and dirty wrapping of too long values
@@ -115,7 +115,7 @@ public class SetParameters extends ConsoleCommand {
 				}
 				s = builder.toString();
 			}
-			consoleIO.writeln(key + ": " + s);			
+			consoleIO.writeln(key + ": " + s);
 		} else {
 			consoleIO.writeError("Unknown parameter: " + key);
 		}

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/SetParameters.java
@@ -7,10 +7,8 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.command;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.ConsoleParameters;

--- a/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/setting/Prefixes.java
@@ -7,7 +7,6 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.console.setting;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -67,7 +66,7 @@ public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 	 * Default set of namespaces are well-known ones
 	 */
 	public Prefixes() {
-		super(DEFAULT);
+		super(new HashSet<>(DEFAULT));
 	}
 	
 	/**
@@ -137,7 +136,7 @@ public class Prefixes extends ConsoleSetting<Set<Namespace>> {
 			return;
 		}
 		if (value.equals("<default>")) {
-			set(DEFAULT);
+			set(new HashSet<>(DEFAULT));
 			return;
 		}
 		

--- a/console/src/test/java/org/eclipse/rdf4j/console/setting/AbstractSettingTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/setting/AbstractSettingTest.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.console.command.SetParameters;
 import org.junit.Before;
 
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 /**
  * Abstract class for settings
@@ -35,6 +36,7 @@ public abstract class AbstractSettingTest {
 		
 	@Before
 	public void setUp() {
-		setParameters = new SetParameters(mockConsoleIO, mockConsoleState, settings);
+		MockitoAnnotations.initMocks(this);
+		setParameters = new SetParameters(mockConsoleIO, mockConsoleState, settings);;
 	}
 }

--- a/console/src/test/java/org/eclipse/rdf4j/console/setting/AbstractSettingTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/setting/AbstractSettingTest.java
@@ -1,42 +1,40 @@
 /*******************************************************************************
- * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.console.command;
-
-import org.junit.Before;
-import org.junit.Test;
+package org.eclipse.rdf4j.console.setting;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.rdf4j.console.setting.ConsoleSetting;
+import org.eclipse.rdf4j.console.ConsoleIO;
+import org.eclipse.rdf4j.console.ConsoleState;
+import org.eclipse.rdf4j.console.command.SetParameters;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import org.junit.Before;
+
+import org.mockito.Mock;
 
 /**
- * Test setting parameters
+ * Abstract class for settings
  * 
  * @author Bart Hanssens
  */
-public class SetParametersTest extends AbstractCommandTest {
-	SetParameters setParameters;
+public abstract class AbstractSettingTest {
+	@Mock
+	protected ConsoleIO mockConsoleIO;
 
+	@Mock
+	protected ConsoleState mockConsoleState;
+	
+	SetParameters setParameters;
+	Map<String,ConsoleSetting> settings = new HashMap<>();
+		
 	@Before
 	public void setUp() {
-		Map<String,ConsoleSetting> settings = new HashMap<>();
 		setParameters = new SetParameters(mockConsoleIO, mockConsoleState, settings);
-	}
-
-	@Test
-	public void testUnknownParametersAreErrors() {
-		setParameters.execute("set", "unknown");
-
-		verify(mockConsoleIO).writeError("Unknown parameter: unknown");
-		verifyNoMoreInteractions(mockConsoleIO);
 	}
 }

--- a/console/src/test/java/org/eclipse/rdf4j/console/setting/ConsoleWidthTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/setting/ConsoleWidthTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.console.setting;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 

--- a/console/src/test/java/org/eclipse/rdf4j/console/setting/ConsoleWidthTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/setting/ConsoleWidthTest.java
@@ -1,42 +1,36 @@
 /*******************************************************************************
- * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.console.command;
+package org.eclipse.rdf4j.console.setting;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import org.eclipse.rdf4j.console.setting.ConsoleSetting;
-
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
- * Test setting parameters
- * 
+ * Test console width
  * @author Bart Hanssens
  */
-public class SetParametersTest extends AbstractCommandTest {
-	SetParameters setParameters;
-
+public class ConsoleWidthTest extends AbstractSettingTest {
 	@Before
+	@Override
 	public void setUp() {
-		Map<String,ConsoleSetting> settings = new HashMap<>();
-		setParameters = new SetParameters(mockConsoleIO, mockConsoleState, settings);
+		settings.put(ConsoleWidth.NAME, new ConsoleWidth());
+		super.setUp();
 	}
 
 	@Test
-	public void testUnknownParametersAreErrors() {
-		setParameters.execute("set", "unknown");
+	public void testShowWidth() {
+		setParameters.execute("set", "width=42");
+		
+		setParameters.execute("set", "width");
+		verify(mockConsoleIO).writeln("width: 42");
 
-		verify(mockConsoleIO).writeError("Unknown parameter: unknown");
 		verifyNoMoreInteractions(mockConsoleIO);
 	}
 }

--- a/console/src/test/java/org/eclipse/rdf4j/console/setting/LogLevelTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/setting/LogLevelTest.java
@@ -9,13 +9,15 @@ package org.eclipse.rdf4j.console.setting;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+
 import org.junit.After;
-import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import org.slf4j.LoggerFactory;
 
 /**
@@ -25,6 +27,13 @@ import org.slf4j.LoggerFactory;
  */
 public class LogLevelTest extends AbstractSettingTest {	
 	private Level originalLevel;
+
+	@Before
+	public void setUp() {
+		originalLevel = ((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).getLevel();
+		settings.put(LogLevel.NAME, new LogLevel());
+		super.setUp();
+	}
 
 	@After
 	public void tearDown() throws Exception {

--- a/console/src/test/java/org/eclipse/rdf4j/console/setting/LogLevelTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/setting/LogLevelTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.console.setting;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test log level setting
+ * 
+ * @author Bart Hanssens
+ */
+public class LogLevelTest extends AbstractSettingTest {	
+	private Level originalLevel;
+
+	@After
+	public void tearDown() throws Exception {
+		((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(originalLevel);
+	}
+
+	@Test
+	public void testNoValueShowsCurrentLevel() {
+		Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		logger.setLevel(Level.INFO);
+
+		setParameters.execute("set", "log");
+
+		verify(mockConsoleIO).writeln("log: info");
+		verifyNoMoreInteractions(mockConsoleIO);
+	}
+
+	@Test
+	public void testSettingLogChangesLevel() {
+		Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		logger.setLevel(Level.DEBUG);
+
+		setParameters.execute("set", "log=warning");
+
+		assertEquals(Level.WARN, logger.getLevel());
+	}
+
+	@Test
+	public void testSettingUnknownLevelIsLoggedAsError() {
+		setParameters.execute("set", "log=chatty");
+
+		verify(mockConsoleIO).writeError("unknown logging level: chatty");
+		verifyNoMoreInteractions(mockConsoleIO);
+	}
+
+	@Test
+	public void testLevelsThatDoNotMatchSlf4jAreMapped() {
+		Logger logger = (Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+		logger.setLevel(Level.WARN);
+
+		setParameters.execute("set", "log");
+
+		verify(mockConsoleIO).writeln("log: warning");
+		verifyNoMoreInteractions(mockConsoleIO);
+	}	
+}

--- a/console/src/test/java/org/eclipse/rdf4j/console/setting/PrefixesTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/setting/PrefixesTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *******************************************************************************/
+package org.eclipse.rdf4j.console.setting;
+
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Test namespace prefixes setting
+ * 
+ * @author Bart Hanssens
+ */
+public class PrefixesTest extends AbstractSettingTest {
+	@Before
+	@Override
+	public void setUp() {
+		settings.put(Prefixes.NAME, new Prefixes());
+		super.setUp();
+	}
+
+	@Test
+	public void testClearPrefixes() {
+		setParameters.execute("set", "prefixes=<none>");
+		
+		setParameters.execute("set", "prefixes");
+		verify(mockConsoleIO).writeln("prefixes: ");
+
+		verifyNoMoreInteractions(mockConsoleIO);
+	}
+	
+	@Test
+	public void testDefaultPrefixes() {
+		setParameters.execute("set", "prefixes=<none>");
+		setParameters.execute("set", "prefixes=<default>");
+		
+		setParameters.execute("set", "prefixes");
+		ArgumentCaptor<String> s  = ArgumentCaptor.forClass(String.class);
+		verify(mockConsoleIO).writeln(s.capture());
+		assertTrue("Does not contain dcterms", s.getValue().contains(DCTERMS.NAMESPACE));
+
+		verifyNoMoreInteractions(mockConsoleIO);
+	}
+	
+	@Test
+	public void testNewPrefix() {
+		setParameters.execute("set", "prefixes=<none>");
+		setParameters.execute("set", "prefixes=" + DCTERMS.PREFIX + " " + DCTERMS.NAMESPACE);
+		
+		setParameters.execute("set", "prefixes");
+		ArgumentCaptor<String> s  = ArgumentCaptor.forClass(String.class);
+		verify(mockConsoleIO).writeln(s.capture());
+		assertTrue("Does not contain dcterms", s.getValue().contains(DCTERMS.NAMESPACE));
+
+		verifyNoMoreInteractions(mockConsoleIO);
+	}
+}

--- a/console/src/test/java/org/eclipse/rdf4j/console/setting/QueryPrefixTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/setting/QueryPrefixTest.java
@@ -1,42 +1,37 @@
 /*******************************************************************************
- * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.console.command;
+package org.eclipse.rdf4j.console.setting;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import org.eclipse.rdf4j.console.setting.ConsoleSetting;
-
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
- * Test setting parameters
+ * Test query prefix setting
  * 
  * @author Bart Hanssens
  */
-public class SetParametersTest extends AbstractCommandTest {
-	SetParameters setParameters;
-
+public class QueryPrefixTest extends AbstractSettingTest {
 	@Before
+	@Override
 	public void setUp() {
-		Map<String,ConsoleSetting> settings = new HashMap<>();
-		setParameters = new SetParameters(mockConsoleIO, mockConsoleState, settings);
+		settings.put(QueryPrefix.NAME, new QueryPrefix());
+		super.setUp();
 	}
-
+	
 	@Test
-	public void testUnknownParametersAreErrors() {
-		setParameters.execute("set", "unknown");
+	public void testQueryPrefix() {
+		setParameters.execute("set", "queryPrefix=false");
 
-		verify(mockConsoleIO).writeError("Unknown parameter: unknown");
+		setParameters.execute("set", "queryPrefix");
+		verify(mockConsoleIO).writeln("queryPrefix: false");
+
 		verifyNoMoreInteractions(mockConsoleIO);
-	}
+	}	
 }

--- a/console/src/test/java/org/eclipse/rdf4j/console/setting/QueryPrefixTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/setting/QueryPrefixTest.java
@@ -9,6 +9,7 @@ package org.eclipse.rdf4j.console.setting;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 

--- a/console/src/test/java/org/eclipse/rdf4j/console/setting/ShowPrefixTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/setting/ShowPrefixTest.java
@@ -1,42 +1,38 @@
 /*******************************************************************************
- * Copyright (c) 2016 Eclipse RDF4J contributors.
+ * Copyright (c) 2019 Eclipse RDF4J contributors.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *******************************************************************************/
-package org.eclipse.rdf4j.console.command;
+package org.eclipse.rdf4j.console.setting;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import org.eclipse.rdf4j.console.setting.ConsoleSetting;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
- * Test setting parameters
+ * Test show prefix setting
  * 
  * @author Bart Hanssens
  */
-public class SetParametersTest extends AbstractCommandTest {
-	SetParameters setParameters;
-
+public class ShowPrefixTest extends AbstractSettingTest {
 	@Before
+	@Override
 	public void setUp() {
-		Map<String,ConsoleSetting> settings = new HashMap<>();
-		setParameters = new SetParameters(mockConsoleIO, mockConsoleState, settings);
+		settings.put(ShowPrefix.NAME, new ShowPrefix());
+		super.setUp();
 	}
 
 	@Test
-	public void testUnknownParametersAreErrors() {
-		setParameters.execute("set", "unknown");
-
-		verify(mockConsoleIO).writeError("Unknown parameter: unknown");
+	public void testShowQueryPrefix() {
+		setParameters.execute("set", "showPrefix=true");
+		
+		setParameters.execute("set", "showPrefix");
+		verify(mockConsoleIO).writeln("showPrefix: true");
+		
 		verifyNoMoreInteractions(mockConsoleIO);
 	}
 }


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1259 .

Briefly describe the changes proposed in this PR:

* Use a copy of default namespaces set (otherwise the list can get cleared unintentionally)
* Refactored tests for settings (new subpackage)
* Added unit test for setting namespace prefixes
* Removed unused imports
