### PR TITLE
Fix eclipse/rdf4j#1311 added options to workbench, cleaned up menu

### DIFF
--- a/workbench/src/main/webapp/transformations/create-memory-rdfs-lucene.xsl
+++ b/workbench/src/main/webapp/transformations/create-memory-rdfs-lucene.xsl
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:sparql="http://www.w3.org/2005/sparql-results#" xmlns="http://www.w3.org/1999/xhtml">
+
+	<xsl:include href="../locale/messages.xsl" />
+
+	<xsl:variable name="title">
+		<xsl:value-of select="$repository-create.title" />
+	</xsl:variable>
+
+	<xsl:include href="template.xsl" />
+
+	<xsl:template match="sparql:sparql">
+		<form action="create" method="post">
+			<table class="dataentry">
+				<tbody>
+					<tr>
+						<th>
+							<xsl:value-of select="$repository-type.label" />
+						</th>
+						<td>
+							<select id="type" name="type">
+								<option value="memory-rdfs-lucene">
+									In Memory Store RDFS + Lucene index
+								</option>
+							</select>
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>
+							<xsl:value-of select="$repository-id.label" />
+						</th>
+						<td>
+							<input type="text" id="id" name="Repository ID" size="16"
+								value="memory-rdfs-lucene" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>
+							<xsl:value-of select="$repository-title.label" />
+						</th>
+						<td>
+							<input type="text" id="title" name="Repository title" size="48"
+								value="Memory store with RDF Schema inferencing and Lucene support" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>
+							<xsl:value-of select="$repository-persist.label" />
+						</th>
+						<td>
+							<input type="radio" name="Persist" size="48"
+								value="true" checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Persist" size="48"
+								value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>
+							<xsl:value-of select="$repository-sync-delay.label" />
+						</th>
+						<td>
+							<input type="text" id="delay" name="Sync delay" size="4"
+								value="0" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td></td>
+						<td>
+							<input type="button" value="{$cancel.label}" style="float:right"
+								data-href="repositories"
+                                onclick="document.location.href=this.getAttribute('data-href')" />
+							<input id="create" type="button" value="{$create.label}"
+								onclick="checkOverwrite()" />
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</form>
+		<script src="../../scripts/create.js" type="text/javascript">
+		</script>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/workbench/src/main/webapp/transformations/create-native-rdfs-lucene.xsl
+++ b/workbench/src/main/webapp/transformations/create-native-rdfs-lucene.xsl
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:sparql="http://www.w3.org/2005/sparql-results#" xmlns="http://www.w3.org/1999/xhtml">
+
+	<xsl:include href="../locale/messages.xsl" />
+
+	<xsl:variable name="title">
+		<xsl:value-of select="$repository-create.title" />
+	</xsl:variable>
+
+	<xsl:include href="template.xsl" />
+
+	<xsl:template match="sparql:sparql">
+		<form action="create" method="post">
+			<table class="dataentry">
+				<tbody>
+					<tr>
+						<th>
+							<xsl:value-of select="$repository-type.label" />
+						</th>
+						<td>
+							<select id="type" name="type">
+								<option value="native-rdfs-lucene">
+									Native Java Store RDFS + Lucene index
+								</option>
+							</select>
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>
+							<xsl:value-of select="$repository-id.label" />
+						</th>
+						<td>
+							<input type="text" id="id" name="Repository ID" size="16"
+								value="native-rdfs" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>
+							<xsl:value-of select="$repository-title.label" />
+						</th>
+						<td>
+							<input type="text" id="title" name="Repository title" size="48"
+								value="Native store with RDF Schema inferencing" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>
+							<xsl:value-of select="$repository-indexes.label" />
+						</th>
+						<td>
+							<input type="text" id="indexes" name="Triple indexes" size="16"
+								value="spoc,posc" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<td></td>
+						<td>
+							<input type="button" value="{$cancel.label}" style="float:right"
+								data-href="repositories"
+                                onclick="document.location.href=this.getAttribute('data-href')" />
+							<input id="create" type="button" value="{$create.label}"
+								onclick="checkOverwrite()" />
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</form>
+		<script src="../../scripts/create.js" type="text/javascript">
+		</script>
+	</xsl:template>
+
+</xsl:stylesheet>

--- a/workbench/src/main/webapp/transformations/create.xsl
+++ b/workbench/src/main/webapp/transformations/create.xsl
@@ -25,60 +25,59 @@
 						<td>
 							<select id="type" name="type">
 								<option value="memory">
-									In Memory Store
-								</option>
-								<option value="memory-rdfs">
-									In Memory Store RDF Schema
-								</option>
-								<option value="memory-rdfs-dt">
-									In Memory Store RDF Schema and
-									Direct Type
-									Hierarchy
-								</option>
-								<option value="memory-spin">
-									In Memory Java Store with basic SPIN support
+									Memory Store
 								</option>
 								<option value="memory-lucene">
-									In Memory Store with Lucene support
+									Memory Store + Lucene 
                                 </option>
-								<option value="memory-spin-rdfs">
-									In Memory Store with RDFS+SPIN support
+								<option value="memory-rdfs">
+									Memory Store + RDFS
 								</option>
-                                <option value="memory-spin-rdfs-lucene">
-                                    In Memory Store with RDFS+SPIN+Lucene support
-                                </option>
+								<option value="memory-rdfs-dt">
+									Memory Store + RDFS and Direct Type
+								</option>
+								<option value="memory-rdfs-lucene">
+									Memory Store + RDFS and Lucene
+								</option>
 								<option value="memory-customrule">
-									In Memory Store Custom Graph Query
-									Inference
+									Memory Store + Custom Graph Query Inference
 								</option>
+								<option value="memory-spin">
+									Memory Store + SPIN support
+								</option>
+								<option value="memory-spin-rdfs">
+									Memory Store + RDFS and SPIN support
+								</option>
+                                <!-- disabled pending GH-1304  option value="memory-spin-rdfs-lucene">
+                                    In Memory Store with RDFS+SPIN+Lucene support
+                                </option -->
 								<option value="native">
-									Native Java Store
+									Native Store
 								</option>
+								<option value="native-lucene">
+                                   Native Store + Lucene
+                                </option>
 								<option value="native-rdfs">
-									Native Java Store RDF Schema
+									Native Store + RDFS
 								</option>
 								<option value="native-rdfs-dt">
-									Native Java Store RDF Schema and
-									Direct Type
-									Hierarchy
+									Native Store + RDFS and Direct Type
+								</option>
+								<option value="memory-rdfs-lucene">
+									Native Store + RDFS and Lucene
 								</option>
 								<option value="native-customrule">
-									Native Java Store Custom
-									Graph Query
-									Inference
+									Native Store + Custom Graph Query Inference
 								</option>
 								<option value="native-spin">
-									Native Java Store with basic SPIN support
+									Native Store + SPIN support
 								</option>
-                                <option value="native-lucene">
-                                    Native Java Store with Lucene support
-                                </option>
 								<option value="native-spin-rdfs">
-									Native Java Store with RDFS+SPIN support
+									Native Store + RDFS and SPIN support
 								</option>
-                                <option value="native-spin-rdfs-lucene">
+                                <!-- disabled pending GH-1304  option value="native-spin-rdfs-lucene">
 									Native Java Store with RDFS+SPIN+Lucene support
-								</option>
+								</option -->
 								<option value="remote">
 									Remote RDF Store
 								</option>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1311 .

Briefly describe the changes proposed in this PR:

* added workbench options to select native/memory with rdfs and lucene
* disabled rdfs+spin+lucene combo as per eclipse/rdf4j#1304
* cleaned up workbench repo type selection dropdown a little
