### PR TITLE
Fix and test for NPE when missing binding value

### DIFF
--- a/console/src/main/java/org/eclipse/rdf4j/console/util/ConsoleQueryResultWriter.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/util/ConsoleQueryResultWriter.java
@@ -125,10 +125,10 @@ public class ConsoleQueryResultWriter extends AbstractQueryResultWriter {
 	@Override
 	public void handleSolution(BindingSet bindingSet) throws TupleQueryResultHandlerException {
 		StringBuilder builder = new StringBuilder(512);
-						
+
 		for (String bindingName : bindingNames) {
 			Value value = bindingSet.getValue(bindingName);
-			String valueStr = Util.getPrefixedValue(value, namespaces);
+			String valueStr = (value != null) ? Util.getPrefixedValue(value, namespaces) : "";
 			builder.append("| ").append(valueStr);
 			StringUtil.appendN(' ', columnWidth - valueStr.length(), builder);
 		}

--- a/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/command/SparqlTest.java
@@ -76,6 +76,12 @@ public class SparqlTest extends AbstractCommandTest {
 		sparql.executeQuery("select ?s ?p ?o where { ?s ?p ?o }", "select");
 		verify(mockConsoleIO, never()).writeError(anyString());
 	}
+
+	@Test
+	public final void testSelectMissingBindings() throws IOException {
+		sparql.executeQuery("select ?s ?p ?o where { ?s a foaf:Organization }", "select");
+		verify(mockConsoleIO, never()).writeError(anyString());
+	}
 	
 	@Test
 	public final void testInputFile() throws IOException {


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1342 .

Briefly describe the changes proposed in this PR:

* Fix NPE by using an empty string when there is no value for a binding/column
* Added test case
