### PR TITLE
Added missing sparqlbuilder module

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -387,6 +387,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.eclipse.rdf4j</groupId>
+				<artifactId>rdf4j-sparqlbuilder</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.rdf4j</groupId>
 				<artifactId>rdf4j-storage-compliance</artifactId>
 				<version>${project.version}</version>
 			</dependency>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1356 .

Briefly describe the changes proposed in this PR:

* Added `rdf4j-sparqlbuilder` module to the bill of materials POM
