### PR TITLE
Issues/#1365 console shacl

### DIFF
--- a/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
@@ -166,7 +166,7 @@ public class Verify extends ConsoleCommand {
 		// load shapes first
 		boolean loaded = false;
 		try {
-			consoleIO.writeError("Loading shapes from " + shaclPath);
+			consoleIO.writeln("Loading shapes from " + shaclPath);
 
 			URL shaclURL = new URL(shaclPath);
 			RDFFormat format = Rio.getParserFormatForFileName(shaclPath).orElseThrow(Rio.unsupportedFormat(shaclPath));
@@ -182,7 +182,7 @@ public class Verify extends ConsoleCommand {
 		}
 
 		if (!loaded) {
-			consoleIO.writeln("No shapes found");
+			consoleIO.writeError("No shapes found");
 			repo.shutDown();
 			return;
 		}
@@ -206,7 +206,7 @@ public class Verify extends ConsoleCommand {
 		} catch (RepositoryException e) {
 			Throwable cause = e.getCause();
 			if (cause instanceof ShaclSailValidationException) {
-				consoleIO.writeln("SHACL validation failed, writing report to " + reportFile);
+				consoleIO.writeError("SHACL validation failed, writing report to " + reportFile);
 				ShaclSailValidationException sv = (ShaclSailValidationException) cause;
 				writeReport(sv.validationReportAsModel(), reportFile);
 			}

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
@@ -9,11 +9,21 @@ package org.eclipse.rdf4j.console.command;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.eclipse.rdf4j.console.ConsoleIO;
 import org.eclipse.rdf4j.console.VerificationListener;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.vocabulary.RDF4J;
+
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
@@ -23,6 +33,10 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.UnsupportedRDFormatException;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.sail.shacl.ShaclSail;
+import org.eclipse.rdf4j.sail.shacl.ShaclSailValidationException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +44,7 @@ import org.slf4j.LoggerFactory;
  * Verify command
  * 
  * @author Dale Visser
+ * @author Bart Hanssens
  */
 public class Verify extends ConsoleCommand {
 	private static final Logger LOGGER = LoggerFactory.getLogger(Verify.class);
@@ -46,8 +61,9 @@ public class Verify extends ConsoleCommand {
 
 	@Override
 	public String getHelpLong() {
-		return PrintHelp.USAGE + "verify <file-or-url>\n"
-				+ "  <file-or-url>   The path or URL identifying the data file\n"
+		return PrintHelp.USAGE + "verify <location> [<shacl-location> <report.ttl>]\n"
+				+ "  <location>                               The file path or URL identifying the data file\n"
+				+ "  <location> <shacl-location> <report.ttl> Validate using shacl file and create a report\n"
 				+ "Verifies the validity of the specified data file\n";
 	}
 
@@ -62,17 +78,35 @@ public class Verify extends ConsoleCommand {
 
 	@Override
 	public void execute(String... tokens) {
-		if (tokens.length != 2) {
+		if (tokens.length != 2 && tokens.length != 4) {
 			consoleIO.writeln(getHelpLong());
 			return;
 		}
-		String dataPath = parseDataPath(tokens);
+
+		String dataPath = parseDataPath(tokens[1]);
+		verify(dataPath);
+
+		if (tokens.length == 4) {
+			String shaclPath = parseDataPath(tokens[2]);
+			String reportFile = tokens[3];
+
+			shacl(dataPath, shaclPath, reportFile);
+		}
+	}
+
+	/**
+	 * Verify an RDF file, either a local file or URL.
+	 * 
+	 * @param tokens parameters
+	 */
+	private void verify(String dataPath) {
 		try {
 			URL dataURL = new URL(dataPath);
 			RDFFormat format = Rio.getParserFormatForFileName(dataPath).orElseThrow(Rio.unsupportedFormat(dataPath));
-			consoleIO.writeln("RDF Format is " + format.getName());
-
 			RDFParser parser = Rio.createParser(format);
+
+			consoleIO.writeln("RDF Format is " + parser.getRDFFormat().getName());
+
 			VerificationListener listener = new VerificationListener(consoleIO);
 
 			parser.set(BasicParserSettings.VERIFY_DATATYPE_VALUES, true);
@@ -118,14 +152,76 @@ public class Verify extends ConsoleCommand {
 	}
 
 	/**
-	 * Parse URL or path to local file. Only the second (index 1) token will be parsed, files will be prefixed with
-	 * "file:" scheme
+	 * Validate an RDF data source using a SHACL file or URL, writing the report to a file
 	 * 
-	 * @param tokens array of tokens to be parsed
+	 * @param dataPath  file or URL of the data to be validated
+	 * @param shaclPath file or URL of the SHACL
+	 * @parem reportFile file to write validation report to
+	 */
+	private void shacl(String dataPath, String shaclPath, String reportFile) {
+		ShaclSail sail = new ShaclSail(new MemoryStore());
+		SailRepository repo = new SailRepository(sail);
+		repo.init();
+
+		// load shapes first
+		boolean loaded = false;
+		try {
+			consoleIO.writeError("Loading shapes from " + shaclPath);
+
+			URL shaclURL = new URL(shaclPath);
+			RDFFormat format = Rio.getParserFormatForFileName(shaclPath).orElseThrow(Rio.unsupportedFormat(shaclPath));
+
+			try (SailRepositoryConnection conn = repo.getConnection()) {
+				conn.add(shaclURL, "", format, RDF4J.SHACL_SHAPE_GRAPH);
+			}
+			loaded = true;
+		} catch (MalformedURLException e) {
+			consoleIO.writeError("Malformed URL: " + shaclPath);
+		} catch (IOException e) {
+			consoleIO.writeError("Failed to load shacl shapes: " + e.getMessage());
+		}
+
+		if (!loaded) {
+			consoleIO.writeln("No shapes found");
+			repo.shutDown();
+			return;
+		}
+
+		sail.setParallelValidation(false);
+		sail.setRdfsSubClassReasoning(false);
+
+		try {
+			URL dataURL = new URL(dataPath);
+			RDFFormat format = Rio.getParserFormatForFileName(dataPath).orElseThrow(Rio.unsupportedFormat(dataPath));
+
+			try (SailRepositoryConnection conn = repo.getConnection()) {
+				conn.add(dataURL, "", format);
+			}
+
+			consoleIO.writeln("SHACL validation OK");
+		} catch (MalformedURLException e) {
+			consoleIO.writeError("Malformed URL: " + dataPath);
+		} catch (IOException e) {
+			consoleIO.writeError("Failed to load data: " + e.getMessage());
+		} catch (RepositoryException e) {
+			Throwable cause = e.getCause();
+			if (cause instanceof ShaclSailValidationException) {
+				consoleIO.writeln("SHACL validation failed, writing report to " + reportFile);
+				ShaclSailValidationException sv = (ShaclSailValidationException) cause;
+				writeReport(sv.validationReportAsModel(), reportFile);
+			}
+		}
+		repo.shutDown();
+	}
+
+	/**
+	 * Parse URL or path to local file. Files will be prefixed with "file:" scheme
+	 * 
+	 * @param str
 	 * @return URL path as string
 	 */
-	private String parseDataPath(String... tokens) {
-		StringBuilder dataPath = new StringBuilder(tokens[1]);
+	private String parseDataPath(String str) {
+		StringBuilder dataPath = new StringBuilder(str);
 		try {
 			new URL(dataPath.toString());
 			// dataPath is a URI
@@ -134,5 +230,19 @@ public class Verify extends ConsoleCommand {
 			dataPath.insert(0, "file:");
 		}
 		return dataPath.toString();
+	}
+
+	/**
+	 * Write SHACL validation report to a file
+	 * 
+	 * @param model      report
+	 * @param reportFile file name
+	 */
+	private void writeReport(Model model, String reportFile) {
+		try (Writer w = Files.newBufferedWriter(Paths.get(reportFile))) {
+			Rio.write(model, w, RDFFormat.TURTLE);
+		} catch (IOException ex) {
+			consoleIO.writeError("Could not write report to " + reportFile);
+		}
 	}
 }

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
@@ -156,7 +156,7 @@ public class Verify extends ConsoleCommand {
 	}
 
 	/**
-	 * Validate an RDF data source using a SHACL file or URL, writing the report to a file
+	 * Validate an RDF data source using a SHACL file or URL, writing the report to a file.
 	 * 
 	 * @param dataPath   file or URL of the data to be validated
 	 * @param shaclPath  file or URL of the SHACL
@@ -169,13 +169,13 @@ public class Verify extends ConsoleCommand {
 
 		sail.disableValidation();
 
-		// load shapes first
+		// load shapes first from a file or URL, defaults to turtle, so one can use .shacl as file extension
 		boolean loaded = false;
 		try {
 			consoleIO.writeln("Loading shapes from " + shaclPath);
 
 			URL shaclURL = new URL(shaclPath);
-			RDFFormat format = Rio.getParserFormatForFileName(shaclPath).orElseThrow(Rio.unsupportedFormat(shaclPath));
+			RDFFormat format = Rio.getParserFormatForFileName(reportFile).orElse(RDFFormat.TURTLE);
 
 			try (SailRepositoryConnection conn = repo.getConnection()) {
 				conn.begin(IsolationLevels.NONE);
@@ -242,7 +242,8 @@ public class Verify extends ConsoleCommand {
 	}
 
 	/**
-	 * Write SHACL validation report to a file
+	 * Write SHACL validation report to a file.
+	 * File extension is used to select the serialization format, TTL is used as default.
 	 * 
 	 * @param model      report
 	 * @param reportFile file name
@@ -250,9 +251,12 @@ public class Verify extends ConsoleCommand {
 	private void writeReport(Model model, String reportFile) {
 		WriterConfig cfg = new WriterConfig();
 		cfg.set(BasicWriterSettings.PRETTY_PRINT, true);
+		cfg.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
+
+		RDFFormat format = Rio.getParserFormatForFileName(reportFile).orElse(RDFFormat.TURTLE);
 
 		try (Writer w = Files.newBufferedWriter(Paths.get(reportFile))) {
-			Rio.write(model, w, RDFFormat.TURTLE, cfg);
+			Rio.write(model, w, format, cfg);
 		} catch (IOException ex) {
 			consoleIO.writeError("Could not write report to " + reportFile);
 		}

--- a/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
+++ b/console/src/main/java/org/eclipse/rdf4j/console/command/Verify.java
@@ -242,8 +242,8 @@ public class Verify extends ConsoleCommand {
 	}
 
 	/**
-	 * Write SHACL validation report to a file.
-	 * File extension is used to select the serialization format, TTL is used as default.
+	 * Write SHACL validation report to a file. File extension is used to select the serialization format, TTL is used
+	 * as default.
 	 * 
 	 * @param model      report
 	 * @param reportFile file name

--- a/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -100,4 +100,20 @@ public class VerifyTest extends AbstractCommandTest {
 		cmd.execute("verify", copyFromRes("wrong_lang.ttl"));
 		assertTrue(io.wasErrorWritten());
 	}
+
+	@Test
+	public final void testShaclInvalid() throws IOException {
+		File report = LOCATION.newFile();
+		cmd.execute("verify", copyFromRes("ok.ttl"), copyFromRes("shacl_invalid.ttl"), report.toString());
+		assertTrue(io.wasErrorWritten());
+		assertTrue(Files.size(report.toPath()) > 0);
+	}
+	
+	@Test
+	public final void testShaclValid() throws IOException {
+		File report = LOCATION.newFile();
+		cmd.execute("verify", copyFromRes("ok.ttl"), copyFromRes("shacl_valid.ttl"), report.toString());
+		assertFalse(Files.size(report.toPath()) > 0);
+		assertFalse(io.wasErrorWritten());
+	}
 }

--- a/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
+++ b/console/src/test/java/org/eclipse/rdf4j/console/command/VerifyTest.java
@@ -108,7 +108,7 @@ public class VerifyTest extends AbstractCommandTest {
 		assertTrue(io.wasErrorWritten());
 		assertTrue(Files.size(report.toPath()) > 0);
 	}
-	
+
 	@Test
 	public final void testShaclValid() throws IOException {
 		File report = LOCATION.newFile();

--- a/console/src/test/resources/verify/shacl_invalid.ttl
+++ b/console/src/test/resources/verify/shacl_invalid.ttl
@@ -1,0 +1,11 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:ExampleShape
+ a sh:NodeShape ;
+ sh:targetClass <http://example.rdf4j.org/ns/example> ;
+ sh:property ex:ExampleShapeProperty .
+
+ex:ExampleShapeProperty
+  sh:path ex:age ;
+  sh:minCount 1 .

--- a/console/src/test/resources/verify/shacl_valid.ttl
+++ b/console/src/test/resources/verify/shacl_valid.ttl
@@ -1,0 +1,11 @@
+@prefix ex: <http://example.com/ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:ExampleShape
+ a sh:NodeShape ;
+ sh:targetClass <http://example.rdf4j.org/ns/example> ;
+ sh:property ex:ExampleShapeProperty .
+
+ex:ExampleShapeProperty
+  sh:path ex:age ;
+  sh:maxCount 1 .


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1365 .

Briefly describe the changes proposed in this PR:

* Add option to Verify command to validate RDF data using a SHACL file + write result to report file

File is loaded into a memory, seems to work quite well even for 500K triples
