### PR TITLE
Use https when downloading Rdf4j artifacts.

### DIFF
--- a/assembly/src/main/dist/docker/Dockerfile
+++ b/assembly/src/main/dist/docker/Dockerfile
@@ -9,7 +9,7 @@ ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j"
 RUN adduser -S tomcat 
 
 RUN cd /tmp && \
-	wget -q "http://www.eclipse.org/downloads/download.php?file=/rdf4j/eclipse-rdf4j-${VERSION}-sdk.zip&r=1" -O /tmp/rdf4j.zip && \
+	wget -q "https://www.eclipse.org/downloads/download.php?file=/rdf4j/eclipse-rdf4j-${VERSION}-sdk.zip&r=1" -O /tmp/rdf4j.zip && \
 	unzip -q /tmp/rdf4j.zip && \
 	rm -rf /usr/local/tomcat/webapps/* && \
 	cp /tmp/eclipse-rdf4j-${VERSION}/war/*.war /usr/local/tomcat/webapps && \

--- a/assembly/src/main/dist/docker/Dockerfile.amd64
+++ b/assembly/src/main/dist/docker/Dockerfile.amd64
@@ -9,7 +9,7 @@ ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j"
 RUN adduser -S tomcat 
 
 RUN cd /tmp && \
-	wget -q "http://www.eclipse.org/downloads/download.php?file=/rdf4j/eclipse-rdf4j-${VERSION}-sdk.zip&r=1" -O /tmp/rdf4j.zip && \
+	wget -q "https://www.eclipse.org/downloads/download.php?file=/rdf4j/eclipse-rdf4j-${VERSION}-sdk.zip&r=1" -O /tmp/rdf4j.zip && \
 	unzip -q /tmp/rdf4j.zip && \
 	rm -rf /usr/local/tomcat/webapps/* && \
 	cp /tmp/eclipse-rdf4j-${VERSION}/war/*.war /usr/local/tomcat/webapps && \

--- a/assembly/src/main/dist/docker/Dockerfile.arm64v8
+++ b/assembly/src/main/dist/docker/Dockerfile.arm64v8
@@ -9,7 +9,7 @@ ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j"
 RUN adduser -S tomcat 
 
 RUN cd /tmp && \
-	wget -q "http://www.eclipse.org/downloads/download.php?file=/rdf4j/eclipse-rdf4j-${VERSION}-sdk.zip&r=1" -O /tmp/rdf4j.zip && \
+	wget -q "https://www.eclipse.org/downloads/download.php?file=/rdf4j/eclipse-rdf4j-${VERSION}-sdk.zip&r=1" -O /tmp/rdf4j.zip && \
 	unzip -q /tmp/rdf4j.zip && \
 	rm -rf /usr/local/tomcat/webapps/* && \
 	cp /tmp/eclipse-rdf4j-${VERSION}/war/*.war /usr/local/tomcat/webapps && \


### PR DESCRIPTION
Even if Eclipse.org immediately redirects to http, make the initial
connection over https for code that's being trusted.
