### PR TITLE
Fixed javadoc errors in maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,9 @@
 								</goals>
 							</execution>
 						</executions>
+						<configuration>
+							<source>8</source>
+						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -181,6 +184,9 @@
 								</goals>
 							</execution>
 						</executions>
+						<configuration>
+							<source>8</source>
+						</configuration>
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR addresses GitHub issue: eclipse/rdf4j#1148 .

Briefly describe the changes proposed in this PR:

* Fix JDK 11 javadoc error: add source parameter to maven javadoc plugin
